### PR TITLE
Fixed std list, removed next functions

### DIFF
--- a/midgard/std/list.yr
+++ b/midgard/std/list.yr
@@ -50,16 +50,6 @@ def pop (T) (ref a : List!T) -> T {
     }    
 }
 
-def next (T) (ref list : List!T) -> mut p!Node {
-    return list.head;
-}
-
-def next (T) (nodePtr : p!(Node!T)) -> mut p!(Node!T) {
-    if (nodePtr is null)
-        return null;
-    return (*nodePtr).next;
-}
-
 def print (T) (const a : List!T) {
     let current = a.head;
     while current !is null {


### PR DESCRIPTION
Maintenant on peut se passer du (*truc).machin pour écrire truc.machin. Du coup ces dernières fonctions ne fonctionnaient plus, et ne sont plus vraiment utiles.