### PR TITLE
[YMI-119][feat] Support toml array-of-tables syntax

### DIFF
--- a/midgard/std/config/data/dict.yr
+++ b/midgard/std/config/data/dict.yr
@@ -1,6 +1,7 @@
 in dict;
 
 use std::{stream, conv};
+use std::algorithm::sorting;
 use std::config::errors;
 
 /**
@@ -158,6 +159,30 @@ pub class Dict over Config {
      */
     pub over opContains(self, k: [c8])-> bool {
         k in self._content
+    }
+
+    /**
+     * @returns: the keys of the dictionnary, sorted in ascending order
+     * @info: iterating a dictionnary(`d[]`) traverses the underlying hash map in bucket order,
+     *   which is neither the insertion order, nor stable when the map grows and is rehashed.
+     *   Serializers use this function instead, so that dumping a configuration twice produces the
+     *   same text, and so that adding a key does not reorder the ones already there.
+     * @example:
+     * ```
+     * let dmut dict = copy Dict();
+     * dict["version"] = copy Int(2);
+     * dict["name"] = copy Str("foo");
+     *
+     * assert(dict.sortedKeys() == ["name", "version"]);
+     * ```
+     */
+    pub fn sortedKeys(self)-> [[c8]] {
+        let dmut keys: [[c8]] = [];
+        for k, _ in self._content {
+            keys ~= [k];
+        }
+
+        sorting::sort(alias keys)
     }
 
     /**

--- a/midgard/std/config/json/dumper.yr
+++ b/midgard/std/config/json/dumper.yr
@@ -131,18 +131,21 @@ pub record JsonDumper {
         }
 
         let mut z = 0us;
-        for k, v in d[] {
-            if z != 0 {
-                stream:.write(",\n");
-                for _ in 0 .. indent + 3 {
-                    stream:.write(" ");
+        let content = d[];
+        for k in d.sortedKeys() { // sorted, so that dumping twice produces the same text
+            if let Ok(v) = content[k] {
+                if z != 0 {
+                    stream:.write(",\n");
+                    for _ in 0 .. indent + 3 {
+                        stream:.write(" ");
+                    }
                 }
-            }
 
-            self.dumpString(k, alias stream);
-            stream:.write(" : ");
-            self.dump(v, alias stream, indent + cast!i32(k.len) + 3, indent + 3);
-            z += 1;
+                self.dumpString(k, alias stream);
+                stream:.write(" : ");
+                self.dump(v, alias stream, indent + cast!i32(k.len) + 3, indent + 3);
+                z += 1;
+            }
         }
 
         if d[].len != 0 {

--- a/midgard/std/config/toml/dumper.yr
+++ b/midgard/std/config/toml/dumper.yr
@@ -109,32 +109,35 @@ pub record TomlDumper {
         let dmut inner = copy StringStream();
         let dmut superStream = copy StringStream();
 
-        for k, v in d[] {
-            if let a: &Array = v && self.isTableArray(a) {
-                self.dumpTableArray(a, baseName ~ k, alias inner);
-            }
+        let content = d[];
+        for k in d.sortedKeys() { // sorted, so that dumping twice produces the same text
+            if let Ok(v) = content[k] {
+                if let a: &Array = v && self.isTableArray(a) {
+                    self.dumpTableArray(a, baseName ~ k, alias inner);
+                }
 
-            else if let iD: &Dict = v {
-                let mut others = false;
-                for _, iV in iD[] { // check wether the inner dict contains only tables
-                    if (iV !of Dict) && !self.isTableArray(iV) {
-                        others = true;
-                        break;
+                else if let iD: &Dict = v {
+                    let mut others = false;
+                    for _, iV in iD[] { // check wether the inner dict contains only tables
+                        if (iV !of Dict) && !self.isTableArray(iV) {
+                            others = true;
+                            break;
+                        }
+                    }
+
+                    if (others) {
+                        inner:.write("\n[", baseName, k, "]\n");
+                        self.dumpGlobalDict(iD, baseName-> baseName ~ k ~ ".", alias inner, 0);
+                    } else {
+                        self.dumpSuperDict(iD, baseName ~ k ~ ".", alias inner);
                     }
                 }
 
-                if (others) {
-                    inner:.write("\n[", baseName, k, "]\n");
-                    self.dumpGlobalDict(iD, baseName-> baseName ~ k ~ ".", alias inner, 0);
-                } else {
-                    self.dumpSuperDict(iD, baseName ~ k ~ ".", alias inner);
+                else {
+                    superStream:.write(k, " = ");
+                    self.dump(v, alias superStream, false, 0);
+                    superStream:.write("\n");
                 }
-            }
-
-            else {
-                superStream:.write(k, " = ");
-                self.dump(v, alias superStream, false, 0);
-                superStream:.write("\n");
             }
         }
 
@@ -189,20 +192,23 @@ pub record TomlDumper {
     prv fn dumpGlobalDict(self, d: &Dict, baseName: [c8], dmut stream: &StringStream, indent: i32) {
         let dmut post = copy StringStream(); // the '[[name]]' sections, written after the pairs
         let mut z = 0us;
-        for k, v in d[] {
-            if let a: &Array = v && self.isTableArray(a) {
-                self.dumpTableArray(a, baseName ~ k, alias post);
-            }
-
-            else {
-                if z != 0 for _ in 0 .. indent {
-                    stream:.write(" ");
+        let content = d[];
+        for k in d.sortedKeys() { // sorted, so that dumping twice produces the same text
+            if let Ok(v) = content[k] {
+                if let a: &Array = v && self.isTableArray(a) {
+                    self.dumpTableArray(a, baseName ~ k, alias post);
                 }
 
-                stream:.write(k, " = ");
-                self.dump(v, alias stream, false, indent + cast!i32(k.len) + 3);
-                stream:.write("\n");
-                z += 1;
+                else {
+                    if z != 0 for _ in 0 .. indent {
+                        stream:.write(" ");
+                    }
+
+                    stream:.write(k, " = ");
+                    self.dump(v, alias stream, false, indent + cast!i32(k.len) + 3);
+                    stream:.write("\n");
+                    z += 1;
+                }
             }
         }
 
@@ -219,11 +225,15 @@ pub record TomlDumper {
     prv fn dumpLocalDict(self, d: &Dict, dmut stream: &StringStream, indent: i32) {
         stream:.write('{');
         let mut z = 0us;
-        for k, v in d[] {
-            if z != 0 { stream:.write(", "); }
+        let content = d[];
+        for k in d.sortedKeys() { // sorted, so that dumping twice produces the same text
+            if let Ok(v) = content[k] {
+                if z != 0 { stream:.write(", "); }
 
-            stream:.write(k, " = ");
-            self.dump(v, alias stream, false, indent + cast!i32(k.len) + 3);
+                stream:.write(k, " = ");
+                self.dump(v, alias stream, false, indent + cast!i32(k.len) + 3);
+                z += 1;
+            }
         }
         stream:.write("}");
     }

--- a/midgard/std/config/toml/dumper.yr
+++ b/midgard/std/config/toml/dumper.yr
@@ -56,7 +56,7 @@ pub record TomlDumper {
                 if indent == -1 {
                     self.dumpSuperDict(d, baseName-> "", alias stream);
                 } else if isGlobal {
-                    self.dumpGlobalDict(d, alias stream, indent);
+                    self.dumpGlobalDict(d, baseName-> "", alias stream, indent);
                 } else {
                     self.dumpLocalDict(d, alias stream, indent);
                 }
@@ -109,11 +109,15 @@ pub record TomlDumper {
         let dmut inner = copy StringStream();
         let dmut superStream = copy StringStream();
 
-        for k, v in d[] match v {
-            iD: &Dict => {
+        for k, v in d[] {
+            if let a: &Array = v && self.isTableArray(a) {
+                self.dumpTableArray(a, baseName ~ k, alias inner);
+            }
+
+            else if let iD: &Dict = v {
                 let mut others = false;
-                for _, iV in iD[] { // check wether the inner dict contains only dictionnaries
-                    if (iV !of Dict) {
+                for _, iV in iD[] { // check wether the inner dict contains only tables
+                    if (iV !of Dict) && !self.isTableArray(iV) {
                         others = true;
                         break;
                     }
@@ -121,12 +125,13 @@ pub record TomlDumper {
 
                 if (others) {
                     inner:.write("\n[", baseName, k, "]\n");
-                    self.dumpGlobalDict(iD, alias inner, 0);
+                    self.dumpGlobalDict(iD, baseName-> baseName ~ k ~ ".", alias inner, 0);
                 } else {
                     self.dumpSuperDict(iD, baseName ~ k ~ ".", alias inner);
                 }
             }
-            _ => {
+
+            else {
                 superStream:.write(k, " = ");
                 self.dump(v, alias superStream, false, 0);
                 superStream:.write("\n");
@@ -138,24 +143,70 @@ pub record TomlDumper {
     }
 
     /**
+     * @returns: true iif `c` is a non empty array whose elements are all dictionnaries, and can
+     *   thus be dumped as a list of '[[name]]' headers rather than as an inline array
+     * @params:
+     *    - c: the configuration to test
+     * */
+    prv fn isTableArray(self, c: &Config)-> bool {
+        if let a: &Array = c {
+            if (a.len == 0us) return false;
+            for e in a[] {
+                if (e !of Dict) return false;
+            }
+
+            return true;
+        }
+
+        false
+    }
+
+    /**
+     * Dump an array of dictionnaries as a sequence of '[[name]]' headers
+     * @params:
+     *    - a: the array to dump
+     *    - name: the full name of the array(dots included)
+     *    - stream: the stream to fill
+     * */
+    prv fn dumpTableArray(self, a: &Array, name: [c8], dmut stream: &StringStream) {
+        for e in a[] {
+            if let d: &Dict = e {
+                stream:.write("\n[[", name, "]]\n");
+                self.dumpGlobalDict(d, baseName-> name ~ ".", alias stream, 0);
+            }
+        }
+    }
+
+    /**
      * Dump a global dictionnary(inside a super dict)
      * @params:
      *   - d: the dict to dump
+     *   - baseName: the basename of the current entry(dot terminated), used to name inner
+     *     arrays of tables
      *   - stream: the stream to fill
      *   - indent: the current indentation
      * */
-    prv fn dumpGlobalDict(self, d: &Dict, dmut stream: &StringStream, indent: i32) {
+    prv fn dumpGlobalDict(self, d: &Dict, baseName: [c8], dmut stream: &StringStream, indent: i32) {
+        let dmut post = copy StringStream(); // the '[[name]]' sections, written after the pairs
         let mut z = 0us;
         for k, v in d[] {
-            if z != 0 for _ in 0 .. indent {
-                stream:.write(" ");
+            if let a: &Array = v && self.isTableArray(a) {
+                self.dumpTableArray(a, baseName ~ k, alias post);
             }
 
-            stream:.write(k, " = ");
-            self.dump(v, alias stream, false, indent + cast!i32(k.len) + 3);
-            stream:.write("\n");
-            z += 1;
+            else {
+                if z != 0 for _ in 0 .. indent {
+                    stream:.write(" ");
+                }
+
+                stream:.write(k, " = ");
+                self.dump(v, alias stream, false, indent + cast!i32(k.len) + 3);
+                stream:.write("\n");
+                z += 1;
+            }
         }
+
+        stream:.write(post[]);
     }
 
     /**

--- a/midgard/std/config/toml/parser.yr
+++ b/midgard/std/config/toml/parser.yr
@@ -63,8 +63,17 @@ pub record TomlParser {
                 break;
             }
 
-            // Global dict entry
+            // Global dict entry, or array of tables entry
             else if tok == TomlTokens::LCRO {
+                let cursor = self._lex.getCursor();
+                let (second, _, _) = self._lex:.next();
+
+                // a doubled header '[[name]]' declares an element of an array of tables
+                let isTableArray = (second == TomlTokens::LCRO);
+                if (!isTableArray) {
+                    self._lex:.rewind(expand cursor); // rewind the read
+                }
+
                 let (name, lName, cName) = self._lex:.next();
                 let names = self._nameTzer.tokenizeWithoutSkips(name);
                 if (names.len == 0) {
@@ -78,7 +87,12 @@ pub record TomlParser {
                 }
 
                 self:.assertRead(["]"]);
-                result = self.insertInPath(result, names, self:.parseDict(isGlobal-> true));
+                if (isTableArray) {
+                    self:.assertRead(["]"]);
+                    result = self.pushInPath(result, names, self:.parseDict(isGlobal-> true));
+                } else {
+                    result = self.insertInPath(result, names, self:.parseDict(isGlobal-> true));
+                }
             }
 
             // Global var
@@ -132,6 +146,10 @@ pub record TomlParser {
             let (name, l, c) = self._lex:.next();
             if isGlobal && (name == "[" || name.len == 0) {  // read the next global dict
                 self._lex:.rewind(expand cursor); // rewind the read
+                break;
+            }
+
+            if !isGlobal && name == TomlTokens::RACC { // an empty local dict '{}'
                 break;
             }
 
@@ -319,6 +337,8 @@ pub record TomlParser {
 
     /**
      * Insert a value at a specific path
+     * @info: an intermediate node that is an array of tables(created by '[[name]]') is traversed
+     *   through its last element, as the toml specification mandates
      * @params:
      *    - dict: the old configuration
      *    - path: the path of insertion
@@ -342,6 +362,11 @@ pub record TomlParser {
                 found = true;
             }
 
+            else if let a: &Array = v && k == path[0] {
+                res[k] = self.insertInLast(a, path[1 .. $], value, isPush-> false);
+                found = true;
+            }
+
             else {
                 res[k] = v;
             }
@@ -349,6 +374,99 @@ pub record TomlParser {
 
         if !found {
             res[path[0]] = self.insertInPath(copy Dict(), path[1 .. $], value);
+        }
+
+        return alias res;
+    }
+
+    /**
+     * Append a value to the array of tables located at a specific path
+     * @info: if there is no value at `path`, an array is created, if the value at `path` is not an
+     *   array it is replaced by a fresh array containing only `value`
+     * @params:
+     *    - dict: the old configuration
+     *    - path: the path of the array of tables
+     *    - value: the element to append
+     * */
+    prv fn pushInPath(self, dict: &Dict, path: [[c8]], value: &Config)-> dmut &Dict {
+        if path.len == 1 {
+            let dmut res = copy Dict();
+            let dmut arr = copy Array();
+            for k, v in dict[] {
+                if k != path[0] {
+                    res[k] = v;
+                }
+
+                else if let a: &Array = v { // keep the elements already read for that path
+                    for e in a[] {
+                        arr:.push(e);
+                    }
+                }
+            }
+
+            arr:.push(value);
+            res[path[0]] = arr;
+            return alias res;
+        }
+
+        let dmut res = copy Dict();
+        let mut found = false;
+        for k, v in dict[] {
+            if let d: &Dict = v && k == path[0] {
+                res[k] = self.pushInPath(d, path[1 .. $], value);
+                found = true;
+            }
+
+            else if let a: &Array = v && k == path[0] {
+                res[k] = self.insertInLast(a, path[1 .. $], value, isPush-> true);
+                found = true;
+            }
+
+            else {
+                res[k] = v;
+            }
+        }
+
+        if !found {
+            res[path[0]] = self.pushInPath(copy Dict(), path[1 .. $], value);
+        }
+
+        return alias res;
+    }
+
+    /**
+     * Insert(or append) a value inside the last element of an array of tables
+     * @params:
+     *    - array: the array of tables to traverse
+     *    - path: the path of insertion, relative to the last element of `array`
+     *    - value: the value to insert
+     *    - isPush: true iif `value` is a new element of an array of tables at `path`
+     * */
+    prv fn insertInLast(self, array: &Array, path: [[c8]], value: &Config, isPush: bool)-> dmut &Array {
+        let dmut res = copy Array();
+        if (array.len == 0us) { // no element to traverse, the sub table creates the first one
+            if (isPush) {
+                res:.push(self.pushInPath(copy Dict(), path, value));
+            } else {
+                res:.push(self.insertInPath(copy Dict(), path, value));
+            }
+
+            return alias res;
+        }
+
+        let last = array.len - 1us;
+        for i, v in array[] {
+            if let d: &Dict = v && i == last {
+                if (isPush) {
+                    res:.push(self.pushInPath(d, path, value));
+                } else {
+                    res:.push(self.insertInPath(d, path, value));
+                }
+            }
+
+            else {
+                res:.push(v);
+            }
         }
 
         return alias res;

--- a/tests/config.yr
+++ b/tests/config.yr
@@ -93,3 +93,142 @@ __test {
         assert(false);
     }
 }
+
+/**
+ * @returns: the number of times `sub` appears in `s`
+ * */
+fn countSub(s: [c8], sub: [c8])-> usize {
+    let mut res = 0us;
+    if (sub.len == 0us || s.len < sub.len) return res;
+
+    for i in 0us .. (s.len - sub.len + 1us) {
+        if (s[i .. i + sub.len] == sub) { res += 1us; }
+    }
+
+    res
+}
+
+__test {
+    // toml array of tables: '[[x]]' declares a new element of the array stored at 'x'
+    let parsed = toml::parse("[[x]]\na = 1\n[[x]]\na = 2\n");
+
+    {
+        if let a: &Array = parsed["x"] {
+            assert(a.len == 2us);
+            assert(a[0u32]["a"] == 1);
+            assert(a[1u32]["a"] == 2);
+        } else assert(false);
+    } catch {
+        _ => assert(false);
+    }
+}
+
+__test {
+    // an array of dicts is dumped as repeated '[[x]]' headers, not as an inline array
+    let dmut arr = copy Array();
+    let dmut e0 = copy Dict();
+    e0["name"] = copy Str("foo");
+    e0["v"] = copy Int(1);
+
+    let dmut e1 = copy Dict();
+    e1["name"] = copy Str("bar");
+    e1["v"] = copy Int(2);
+
+    arr:.push(e0);
+    arr:.push(e1);
+
+    let dmut d = copy Dict();
+    d["package"] = arr;
+
+    let dumped = toml::dump(d);
+    assert(countSub(dumped, "[[package]]") == 2us);
+
+    let parsed = toml::parse(dumped);
+    {
+        if let a: &Array = parsed["package"] {
+            assert(a.len == 2us);
+            assert(a[0u32]["name"] == "foo");
+            assert(a[0u32]["v"] == 1);
+            assert(a[1u32]["name"] == "bar");
+            assert(a[1u32]["v"] == 2);
+        } else assert(false);
+    } catch {
+        _ => assert(false);
+    }
+}
+
+__test {
+    // dotted path arrays of tables, under a global table that also holds plain values
+    let content = "[deps]\nstrict = true\n\n[[deps.pkg]]\nname = \"a\"\n\n[[deps.pkg]]\nname = \"b\"\n";
+    let parsed = toml::parse(content);
+
+    {
+        assert(parsed["deps"]["strict"] == true);
+        if let a: &Array = parsed["deps"]["pkg"] {
+            assert(a.len == 2us);
+            assert(a[0u32]["name"] == "a");
+            assert(a[1u32]["name"] == "b");
+        } else assert(false);
+    } catch {
+        _ => assert(false);
+    }
+
+    // and it round trips through the dumper
+    let dumped = toml::dump(parsed);
+    assert(countSub(dumped, "[[deps.pkg]]") == 2us);
+
+    let reparsed = toml::parse(dumped);
+    {
+        assert(reparsed["deps"]["strict"] == true);
+        if let a: &Array = reparsed["deps"]["pkg"] {
+            assert(a.len == 2us);
+            assert(a[0u32]["name"] == "a");
+            assert(a[1u32]["name"] == "b");
+        } else assert(false);
+    } catch {
+        _ => assert(false);
+    }
+}
+
+__test {
+    // a sub table of an array of tables applies to the last element read, and round trips
+    let content = "[[srv]]\nport = 80\n\n[srv.tls]\nenabled = false\n\n[[srv]]\nport = 443\n\n[srv.tls]\nenabled = true\n";
+    let parsed = toml::parse(content);
+    let reparsed = toml::parse(toml::dump(parsed));
+
+    {
+        for cfg in [parsed, reparsed] {
+            if let a: &Array = cfg["srv"] {
+                assert(a.len == 2us);
+                assert(a[0u32]["port"] == 80);
+                assert(a[0u32]["tls"]["enabled"] == false);
+                assert(a[1u32]["port"] == 443);
+                assert(a[1u32]["tls"]["enabled"] == true);
+            } else assert(false);
+        }
+    } catch {
+        _ => assert(false);
+    }
+}
+
+__test {
+    // an empty array, or an array that is not made only of dicts, stays an inline array
+    let dmut mixed = copy Array();
+    mixed:.push(copy Int(1));
+    mixed:.push(copy Dict());
+
+    let dmut d = copy Dict();
+    d["empty"] = copy Array();
+    d["mixed"] = mixed;
+
+    let dumped = toml::dump(d);
+    assert(countSub(dumped, "[[") == 0us);
+
+    let parsed = toml::parse(dumped);
+    {
+        if let a: &Array = parsed["empty"] { assert(a.len == 0us); } else assert(false);
+        if let a: &Array = parsed["mixed"] { assert(a.len == 2us); } else assert(false);
+    } catch {
+        _ => assert(false);
+    }
+}

--- a/tests/config.yr
+++ b/tests/config.yr
@@ -232,3 +232,62 @@ __test {
         _ => assert(false);
     }
 }
+
+__test {
+    // keys are dumped sorted, whatever the insertion order, for both toml and json
+    let dmut d = copy Dict();
+    d["version"] = copy Int(1);
+    d["name"] = copy Str("foo");
+    d["about"] = copy Str("bar");
+
+    assert(toml::dump(d) == "about = \"bar\"\nname = \"foo\"\nversion = 1\n");
+    assert(json::dump(d) == "{\n   \"about\" : \"bar\",\n   \"name\" : \"foo\",\n   \"version\" : 1\n}");
+
+    // and the same configuration always dumps to the same text
+    assert(toml::dump(d) == toml::dump(toml::parse(toml::dump(d))));
+    assert(json::dump(d) == json::dump(json::parse(json::dump(d))));
+}
+
+__test {
+    // adding a key never reorders the keys already dumped, whatever the hash map does under it
+    let names = ["a"s8, "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l"];
+    let dmut d = copy Dict();
+    let mut previous: [c8] = "";
+
+    for i in 0us .. names.len {
+        d[names[i]] = copy Int(cast!i64(i));
+        let dumped = toml::dump(d);
+
+        // every line of the previous dump is still there, in the same order
+        assert(dumped[0us .. previous.len] == previous);
+        previous = dumped;
+    }
+}
+
+__test {
+    // an inline dict separates its entries, and thus round trips(the keys being sorted)
+    let dmut inl = copy Dict();
+    inl["b"] = copy Int(2);
+    inl["a"] = copy Int(1);
+
+    let dmut arr = copy Array();
+    arr:.push(copy Int(0));
+    arr:.push(inl); // not a table array, so it stays inline
+
+    let dmut d = copy Dict();
+    d["mixed"] = arr;
+
+    assert(toml::dump(d) == "mixed = [0, {a = 1, b = 2}]\n");
+
+    let parsed = toml::parse(toml::dump(d));
+    {
+        if let a: &Array = parsed["mixed"] {
+            assert(a.len == 2us);
+            assert(a[0u32] == 0);
+            assert(a[1u32]["a"] == 1);
+            assert(a[1u32]["b"] == 2);
+        } else assert(false);
+    } catch {
+        _ => assert(false);
+    }
+}


### PR DESCRIPTION
Closes YMI-119.

## Array of tables

`TomlParser` only understood `[table]`; a doubled `[[table]]` header was rejected, so the natural TOML shape for a list of tables — the one `gyllir.lock` wants for `[[package]]` — had to be worked around as `[package.<name>]`.

**Parser** (`std/config/toml/parser.yr`)
- `parse()` peeks one token after the opening `[`; a second `[` marks an array-of-tables header. The table is appended via the new `pushInPath` instead of `insertInPath`.
- `pushInPath` appends a fresh `&Dict` to the `&Array` at the path, preserving elements already read; if nothing (or a non-array) is there, it starts a new array.
- `insertInPath`/`pushInPath` now descend through an intermediate `&Array` via `insertInLast`, so `[[srv]] … [srv.tls]` and `[[a]] … [[a.b]]` apply to the *last* element read, per the TOML spec. Previously an `&Array` at an intermediate segment was silently overwritten.

**Dumper** (`std/config/toml/dumper.yr`)
- New `isTableArray` (non-empty array whose elements are all dicts) and `dumpTableArray` (one `[[name]]` header per element).
- `dumpSuperDict` routes table arrays to `[[…]]` headers, and its "does this inner dict hold only tables" check now counts a table array as a table, so a dict holding only `[[…]]` entries does not collapse into an inline array.
- `dumpGlobalDict` takes a `baseName` and defers table arrays into a `post` stream written after the section's `key = value` pairs — that is what keeps `[a]` + `[[a.subs]]`, and nested `[[package.dep]]`, in valid order.
- Anything that is not a table array (empty arrays, mixed arrays) still dumps inline.

## Sorted, reproducible dumps

- New `Dict::sortedKeys()` (`std/config/data/dict.yr`), shared by both serializers.
- The TOML dumper (`dumpSuperDict`, `dumpGlobalDict`, `dumpLocalDict`) and the JSON dumper (`dumpDict`) iterate it. Sorting is orthogonal to the stream splitting above, so `key = value` pairs still precede `[table]`/`[[table]]` headers.

## Drive-by fix

`dumpLocalDict` declared `z` but never incremented it, so its `if z != 0 { ", " }` separator never fired: a two-key inline dict dumped as `{a = 1b = 2}`, invalid TOML that would not reparse. It only surfaces for a dict inside a non-table array, which is why no existing test caught it. Fixed while rewriting that loop, and verified by removing the fix again and watching the new test fail.

