### PR TITLE
[YMI-140][fix] Send Connection: close on every http response

### DIFF
--- a/midgard/std/net/http/response.yr
+++ b/midgard/std/net/http/response.yr
@@ -135,6 +135,12 @@ pub record HttpResponse {
         sock:.sendRaw("Content-Length: ");
         sock:.sendRaw(std::conv::to!{[c8]} (self.body.len));
         sock:.sendRaw("\r\n");
+
+        // The worker thread always disposes the socket right after this response is sent
+        // (see HttpServer::workerJobThread), so keep-alive is not actually supported yet;
+        // advertising anything else makes clients (esp. Firefox) try to reuse a dead
+        // connection and eat a stall+reconnect on every following request.
+        sock:.sendRaw("Connection: close\r\n");
         sock:.sendRaw("\r\n");
 
         sock:.sendRaw(self.body);


### PR DESCRIPTION
## Summary
- `HttpServer::workerJobThread` closes the client socket right after sending every response, but `HttpResponse::send()` never told the client that -- browsers see an HTTP/1.1 response with no `Connection` header and assume the connection is keep-alive-capable, then try to reuse an already-dead socket on the next request.
- `HttpResponse::send()` now always emits `Connection: close`, matching what the server actually does.

Found while investigating why `gyllir doc serve` loads documentation very slowly in Firefox: curl reproduces the same symptom (`Connection #0 ... left intact` immediately followed by `Connection 0 seems to be dead` on reuse). Firefox pools/reuses connections more aggressively than curl, so it pays a stall+reconnect on nearly every asset request of a docs page.

## Test plan
- [x] `gyllir build` in this repo compiles cleanly with the change (`libgymidgard_debug.a`, `libgymidgard_release.a`, `midgard_tests` all produced)
- [ ] Once released, re-verify `gyllir doc serve` load time in Firefox against a Gyllir build pinned to this version

https://linear.app/ymir-bootstrap/issue/YMI-140/httpserver-never-sends-connection-close-causing-clients-to-reuse-dead