### PR TITLE
[YMI-141][perf] Optimization pass

### DIFF
--- a/midgard/core/types/hash.yr
+++ b/midgard/core/types/hash.yr
@@ -158,13 +158,9 @@ pub fn __hash(f: f64)-> u64 {
  *    - U: a hashable type
  */
 pub fn __hash {T of [U], U} (a: T)-> u64 {
-    let p = 31u64;
-    let m = 1_000_000_009u64;
-    let mut res = 0u64;
-    let mut p_pow = 1u64;
+    let mut res = 0xcbf29ce484222325u64;
     for c in a {
-        res = (res + (__hash(c) + 1u64) * p_pow) % m;
-        p_pow = (p_pow * p) % m;
+        res = (res ^ __hash(c)) * 0x100000001b3u64;
     }
     res
 }
@@ -177,14 +173,9 @@ pub fn __hash {T of [U], U} (a: T)-> u64 {
  *    - U: a hashable type
  */
 pub fn __hash {T of [U ; N], U, N: usize} (a: T)-> u64 {
-    let p = 31u64;
-    let m = 1_000_000_009u64;
-    let mut res = 0u64;
-    let mut p_pow = 1u64;
-
+    let mut res = 0xcbf29ce484222325u64;
     for c in a {
-        res = (res + (__hash(c) + 1u64) * p_pow) % m;
-        p_pow = (p_pow * p) % m;
+        res = (res ^ __hash(c)) * 0x100000001b3u64;
     }
 
     res
@@ -198,14 +189,9 @@ pub fn __hash {T of [U ; N], U, N: usize} (a: T)-> u64 {
  *    - U: a hashable type
  */
 pub fn __hash {T of [U ; N], U, N: usize} (ref a: T)-> u64 {
-    let p = 31u64;
-    let m = 1_000_000_009u64;
-    let mut res = 0u64;
-    let mut p_pow = 1u64;
-
+    let mut res = 0xcbf29ce484222325u64;
     for c in a {
-        res = (res + (__hash(c) + 1u64) * p_pow) % m;
-        p_pow = (p_pow * p) % m;
+        res = (res ^ __hash(c)) * 0x100000001b3u64;
     }
 
     res

--- a/midgard/std/algorithm/sorting/quick.yr
+++ b/midgard/std/algorithm/sorting/quick.yr
@@ -13,16 +13,37 @@ in quick;
  *    - predicate: the predicate function used to compare elements
  */
 pub fn quicksort {U} (mut a: mut[mut U], predicate: dg (U, U)-> bool) {
-    if (a.len < 2us) {
+    // Below this size, a subrange is sorted with insertion sort rather than
+    // being recursed into further. Insertion sort has less overhead per
+    // element than a quicksort partition, and quicksort's own worst case is
+    // concentrated on small ranges, so this cutoff is a net win in both
+    // average and worst case, matching what libstdc++'s introsort does.
+    if (a.len < 16us) {
+        insertionSort(alias a, predicate);
         return;
     }
 
-    let pivot = a[a.len / 2us];
+    let i = partition(alias a, predicate);
+
+    quicksort(alias a[0us .. i], predicate);
+    quicksort(alias a[i .. $], predicate);
+}
+
+/**
+ * Hoare partition scheme, using the median of the first, middle and last
+ * elements as the pivot, so already sorted (or reverse sorted) input,
+ * a common case in practice, does not degrade into the O(n^2) worst case
+ * that picking a fixed position (e.g. always the middle) would cause.
+ * @returns: the split index `i`, such that `a[0 .. i]` and `a[i .. $]`
+ * can be sorted independently
+ */
+fn partition {U} (mut a: mut[mut U], predicate: dg (U, U)-> bool)-> usize {
+    let pivot = medianOfThree (a, predicate);
     let mut i = 0us, mut j = a.len - 1us;
     loop {
         while (predicate(a[i], pivot)) {
             if (i == a.len) {
-                return;
+                return i;
             }
 
             i += 1us;
@@ -30,7 +51,7 @@ pub fn quicksort {U} (mut a: mut[mut U], predicate: dg (U, U)-> bool) {
 
         while (predicate(pivot, a[j])) {
             if (j == 0us) {
-                return;
+                return j;
             }
 
             j -= 1us;
@@ -54,6 +75,58 @@ pub fn quicksort {U} (mut a: mut[mut U], predicate: dg (U, U)-> bool) {
         j -= 1us;
     }
 
-    quicksort(alias a[0us .. i], predicate);
-    quicksort(alias a[i .. $], predicate);
+    return i;
+}
+
+/**
+ * @returns: the median value of `a[0]`, `a[a.len / 2]` and `a[a.len - 1]`
+ * according to `predicate`
+ */
+fn medianOfThree {U} (a: [U], predicate: dg (U, U)-> bool)-> U {
+    let mid = a.len / 2us;
+    let last = a.len - 1us;
+
+    if (predicate(a[mid], a[0us])) {
+        if (predicate(a[last], a[mid])) {
+            a[mid]
+        } else if (predicate(a[last], a[0us])) {
+            a[last]
+        } else {
+            a[0us]
+        }
+    } else {
+        if (predicate(a[last], a[0us])) {
+            a[0us]
+        } else if (predicate(a[last], a[mid])) {
+            a[last]
+        } else {
+            a[mid]
+        }
+    }
+}
+
+/**
+ * Plain insertion sort, used by `quicksort` to finish off small subranges.
+ */
+fn insertionSort {U} (mut a: mut[mut U], predicate: dg (U, U)-> bool) {
+    if (a.len < 2us) {
+        return;
+    }
+
+    for i in 1us .. a.len {
+        let mut j = i;
+        while (j > 0us && predicate(a[j], a[j - 1us])) {
+            cte if __pragma!compile({a[j] = a[j - 1us];}) {
+                let temp = a[j];
+                a[j] = a[j - 1us];
+                a[j - 1us] = temp;
+            } else { // even if U is not deeply mutable, it may be a structure containing aliasable stuff
+                let mut temp = alias a[j];
+                a[j] = alias a[j - 1us];
+                a[j - 1us] = alias temp;
+            }
+
+            j -= 1us;
+        }
+    }
 }

--- a/midgard/std/conv.yr
+++ b/midgard/std/conv.yr
@@ -196,7 +196,7 @@ pub fn if (isUnsigned!{I} && isChar!{C} && isIntegral!{N}) to {T of [C], C, base
     cte if (base == 10) {
         upper;
         for i in len .. 0us {
-            res[i - 1us] = cast!C(cast!u8('0') + cast!u8(m % b));
+            res[i - 1us] = cast!C(cast!c8(cast!u8('0') + cast!u8(m % b)));
             m /= b;
         }
     } else {
@@ -346,7 +346,7 @@ pub fn if (isSigned!{I} && isChar!{C} && isIntegral!{N}) to {T of [C], C, base: 
         cte if (base == 10) {
             upper;
             for i in len .. 0us {
-                res[i - 1us] = cast!C(cast!u8('0') + cast!u8(m % b));
+                res[i - 1us] = cast!C(cast!c8(cast!u8('0') + cast!u8(m % b)));
                 m /= b;
             }
         } else {
@@ -365,7 +365,7 @@ pub fn if (isSigned!{I} && isChar!{C} && isIntegral!{N}) to {T of [C], C, base: 
         cte if (base == 10) {
             upper;
             for i in len .. 0us {
-                res[i] = cast!C(cast!u8('0') + cast!u8(m % b));
+                res[i] = cast!C(cast!c8(cast!u8('0') + cast!u8(m % b)));
                 m /= b;
             }
         } else {

--- a/midgard/std/conv.yr
+++ b/midgard/std/conv.yr
@@ -190,10 +190,20 @@ pub fn if (isUnsigned!{I} && isChar!{C} && isIntegral!{N}) to {T of [C], C, base
     }
 
     let dmut res = core::types::array::allocArray!(C) (len);
-    let mut j: typeof(n) = 1;
-    for i in len .. 0us {
-        res[i - 1us] = std::conv::utils::to!C((cast!{typeof(n)} (a) / j) % cast!{typeof(n)} (base), cast!{typeof(n)} (base), upper-> upper);
-        j *= cast!{typeof(n)} (base);
+    let mut m: typeof(n) = cast!{typeof(n)} (a);
+    let b: typeof(n) = cast!{typeof(n)} (base);
+
+    cte if (base == 10) {
+        upper;
+        for i in len .. 0us {
+            res[i - 1us] = cast!C(cast!u8('0') + cast!u8(m % b));
+            m /= b;
+        }
+    } else {
+        for i in len .. 0us {
+            res[i - 1us] = std::conv::utils::to!C(m % b, b, upper-> upper);
+            m /= b;
+        }
     }
 
     alias res
@@ -321,27 +331,48 @@ pub fn if (isSigned!{I} && isChar!{C} && isIntegral!{N}) to {T of [C], C, base: 
         (a, 0us, false)
     };
 
+    let absVal: typeof(n) = cast!{typeof(n)} (n);
+    let b: typeof(n) = cast!{typeof(n)} (base);
+
     while n > 0 {
         len += 1;
-        n /= cast!{typeof(n)} (base);
+        n /= b;
     }
 
-    let mut j: __pragma!unproxied(I) = 1;
     if (!sign) {
         let dmut res = core::types::array::allocArray!(C)(len);
-        for i in len .. 0us {
-            res[i - 1us] = std::conv::utils::to!C((cast!{typeof(n)} (a) / j) % cast!{typeof(n)} (base), cast!{typeof(n)} (base), upper);
-            j *= cast!{typeof(n)} (base);
+        let mut m: typeof(n) = absVal;
+
+        cte if (base == 10) {
+            upper;
+            for i in len .. 0us {
+                res[i - 1us] = cast!C(cast!u8('0') + cast!u8(m % b));
+                m /= b;
+            }
+        } else {
+            for i in len .. 0us {
+                res[i - 1us] = std::conv::utils::to!C(m % b, b, upper);
+                m /= b;
+            }
         }
 
         return alias res;
     } else {
         let dmut res = core::types::array::allocArray!(C)(len + 1us);
         res[0] = '-';
+        let mut m: typeof(n) = absVal;
 
-        for i in len .. 0us {
-            res[i] = std::conv::utils::to!C((cast!{typeof(n)} (-a) / j) % cast!{typeof(n)} (base), cast!{typeof(n)} (base), upper);
-            j *= cast!{typeof(n)} (base);
+        cte if (base == 10) {
+            upper;
+            for i in len .. 0us {
+                res[i] = cast!C(cast!u8('0') + cast!u8(m % b));
+                m /= b;
+            }
+        } else {
+            for i in len .. 0us {
+                res[i] = std::conv::utils::to!C(m % b, b, upper);
+                m /= b;
+            }
         }
 
         return alias res;

--- a/rt/concurrency/future.c
+++ b/rt/concurrency/future.c
@@ -17,7 +17,7 @@ _yrt_future_t _yrt_spawn_future (_yrt_lazy_closure_t closure, uint32_t valueSize
     result.content-> valueSize = valueSize;
     result.content-> value = NULL;
 
-    _yrt_thread_create (&result.id, NULL, &_yrt_future_main, result.content);
+    _thread_create (&result.id, NULL, &_future_main, result.content);
     _yrt_thread_sem_wait (&result.content-> wait);
 
     return result;
@@ -26,7 +26,7 @@ _yrt_future_t _yrt_spawn_future (_yrt_lazy_closure_t closure, uint32_t valueSize
 void* _yrt_wait_future (_yrt_future_t f) {
     if (f.content == NULL) return NULL;
     if (selfId == f.id) {
-        _yrt_exc_terminate ("Waiting self thread %lx\n", __FILE__, __FUNCTION__, __LINE__);
+        _exc_terminate ("Waiting self thread %lx\n", __FILE__, __FUNCTION__, __LINE__);
     }
 
     _yrt_thread_mutex_lock (&f.content-> mutex);
@@ -39,7 +39,7 @@ void* _yrt_wait_future (_yrt_future_t f) {
 }
 
 
-void* _yrt_future_main (void * data) {
+void* _future_main (void * data) {
     _yrt_future_content_t * content = (_yrt_future_content_t*) data;
     _yrt_thread_sem_post (&content-> wait);
 

--- a/rt/concurrency/future.h
+++ b/rt/concurrency/future.h
@@ -52,6 +52,6 @@ uint8_t _yrt_check_finished_future (_yrt_future_t f);
 /**
  * The main fonction spawned in a thread computing the value of the future
  */
-void* _yrt_future_main (void * f);
+void* _future_main (void * f);
 
 #endif // FUTURE_H_

--- a/rt/concurrency/thread.c
+++ b/rt/concurrency/thread.c
@@ -21,25 +21,25 @@ _yrt_mutex_t __monitor_mutex__ = PTHREAD_MUTEX_INITIALIZER;
 _yrt_mutex_t __global_atom__ = PTHREAD_MUTEX_INITIALIZER;
 
 #ifdef _WIN32
-void * _yrt_read_pipe (void * stream, unsigned long long size) {
+void * _read_pipe (void * stream, unsigned long long size) {
     void * z;
     void ** x = &z;
     ReadFile (stream, x, size, NULL, NULL);
     return *x;
 }
 
-void _yrt_write_pipe (void* stream, void * data, unsigned long long size) {
+void _write_pipe (void* stream, void * data, unsigned long long size) {
     WriteFile (stream, &data, size, NULL, NULL);
 }
 #else
-void * _yrt_read_pipe (int stream, unsigned long long size) {
+void * _read_pipe (int stream, unsigned long long size) {
     void * z;
     void ** x = &z;
     int r = read (stream, x, size);
     return *x;
 }
 
-void _yrt_write_pipe (int stream, void * data, unsigned long long size) {
+void _write_pipe (int stream, void * data, unsigned long long size) {
     int r = write (stream, &data, size);
 }
 #endif
@@ -62,20 +62,20 @@ typedef struct {
     sem_t copied;
 } _yrt_thread_start_t;
 
-static void _yrt_thread_remove_tls_roots (void * unused) {
+static void _thread_remove_tls_roots (void * unused) {
     (void) unused;
 
-    _yrt_gc_remove_tls_roots ();
+    _gc_remove_tls_roots ();
 }
 
-static void * _yrt_thread_main (void * raw) {
+static void * _thread_main (void * raw) {
     _yrt_thread_start_t * start = (_yrt_thread_start_t*) raw;
     void * (*call) (void*) = start-> call;
     void * data = start-> data;
 
     // '@thread' globals of this thread are unreachable for the collector until this call, so it
     // has to come before any Ymir code runs
-    _yrt_gc_add_tls_roots ();
+    _gc_add_tls_roots ();
 
     // 'start' belongs to the spawning thread's frame and must not be touched from here on
     sem_post (&start-> copied);
@@ -83,32 +83,32 @@ static void * _yrt_thread_main (void * raw) {
     void * result = NULL;
 
     // a cleanup handler rather than a plain call after 'call', so that the roots also go away
-    // when the thread is cancelled(see _yrt_thread_cancel) or exits early
-    pthread_cleanup_push (&_yrt_thread_remove_tls_roots, NULL);
+    // when the thread is cancelled(see _thread_cancel) or exits early
+    pthread_cleanup_push (&_thread_remove_tls_roots, NULL);
     result = call (data);
     pthread_cleanup_pop (1);
 
     return result;
 }
 
-void _yrt_thread_create (_yrt_thread_t * id, _yrt_attr_t* attr, void*(*call)(void*), void* data) {
+void _thread_create (_yrt_thread_t * id, _yrt_attr_t* attr, void*(*call)(void*), void* data) {
     _yrt_thread_start_t start;
     start.call = call;
     start.data = data;
     sem_init (&start.copied, 0, 0);
 
-    if (GC_pthread_create (id, attr, &_yrt_thread_main, &start) == 0) {
+    if (GC_pthread_create (id, attr, &_thread_main, &start) == 0) {
         sem_wait (&start.copied);
     }
 
     sem_destroy (&start.copied);
 }
 
-void _yrt_thread_join (_yrt_thread_t p, void** retval) {
+void _thread_join (_yrt_thread_t p, void** retval) {
     (void) GC_pthread_join (p, retval);
 }
 
-void _yrt_thread_detach (_yrt_thread_t p) {
+void _thread_detach (_yrt_thread_t p) {
     GC_pthread_detach (p);
 }
 
@@ -117,11 +117,11 @@ void _yrt_thread_detach (_yrt_thread_t p) {
 void GC_pthread_cancel (_yrt_thread_t p);
 void GC_pthread_exit (_yrt_thread_t p);
 
-void _yrt_thread_cancel (_yrt_thread_t p) {
+void _thread_cancel (_yrt_thread_t p) {
     GC_pthread_cancel (p);
 }
 
-void _yrt_thread_exit (_yrt_thread_t p) {
+void _thread_exit (_yrt_thread_t p) {
     GC_pthread_exit (p);
 }
 #endif
@@ -229,7 +229,7 @@ int32_t _yrt_thread_sem_get (sem_t * sem) {
     return i;
 }
 
-_yrt_mutex_t * _yrt_ensure_monitor (void* object) {
+_yrt_mutex_t * _ensure_monitor (void* object) {
     pthread_mutex_lock (&__monitor_mutex__);
     _yrt_mutex_t* mut = *((_yrt_mutex_t**) object + 1); // skip the vtable
     if (mut == NULL) {
@@ -256,12 +256,12 @@ void _yrt_unlock_global () {
 }
 
 void _yrt_atomic_monitor_enter (void* object) {
-    _yrt_mutex_t * lock = _yrt_ensure_monitor (object);
+    _yrt_mutex_t * lock = _ensure_monitor (object);
     pthread_mutex_lock (lock);
 }
 
 void _yrt_atomic_monitor_exit (void* object) {
-    _yrt_mutex_t * lock = _yrt_ensure_monitor (object);
+    _yrt_mutex_t * lock = _ensure_monitor (object);
     pthread_mutex_unlock (lock);
 }
 
@@ -300,7 +300,7 @@ uint32_t _yrt_fork () {
 }
 
 
-void _yrt_atomic_init () {
+void _atomic_init () {
     pthread_mutexattr_t attr;
     pthread_mutexattr_init(&attr);
     pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE);

--- a/rt/concurrency/thread.h
+++ b/rt/concurrency/thread.h
@@ -27,9 +27,9 @@ typedef pthread_barrier_t _yrt_barrier_t;
  * @warning: this function is blocking until everything is read, or the pipe is closed
  */
 #ifdef _WIN32
-void * _yrt_read_pipe (void * stream, unsigned long long size);
+void * _read_pipe (void * stream, unsigned long long size);
 #else
-void * _yrt_read_pipe (int stream, unsigned long long size);
+void * _read_pipe (int stream, unsigned long long size);
 #endif
 
 /**
@@ -40,9 +40,9 @@ void * _yrt_read_pipe (int stream, unsigned long long size);
  *    - size: the size (in bytes)
  */
 #ifdef _WIN32
-void _yrt_write_pipe (void * stream, void * data, unsigned long long size);
+void _write_pipe (void * stream, void * data, unsigned long long size);
 #else
-void _yrt_write_pipe (int stream, void * data, unsigned long long size);
+void _write_pipe (int stream, void * data, unsigned long long size);
 #endif
 
 /**
@@ -54,7 +54,7 @@ void _yrt_write_pipe (int stream, void * data, unsigned long long size);
  * @returns:
  *    - id: the id of the created thread
  */
-void _yrt_thread_create (_yrt_thread_t * id, _yrt_attr_t* attr, void*(*call)(void*), void* data);
+void _thread_create (_yrt_thread_t * id, _yrt_attr_t* attr, void*(*call)(void*), void* data);
 
 /**
  * Wait for the completion of a thread
@@ -63,14 +63,14 @@ void _yrt_thread_create (_yrt_thread_t * id, _yrt_attr_t* attr, void*(*call)(voi
  * @returns:
  *    - retval: the return value of the thread
  */
-void _yrt_thread_join (_yrt_thread_t p, void** retval);
+void _thread_join (_yrt_thread_t p, void** retval);
 
 /**
  * Detach a thread from the main thread, but does not kill it
  * @params:
  *    - p: the id of the thread
  */
-void _yrt_thread_detach (_yrt_thread_t p);
+void _thread_detach (_yrt_thread_t p);
 
 /**
  * Create a new mutex
@@ -205,7 +205,7 @@ void _yrt_thread_sem_post (sem_t * sem);
  * @params:
  *   - object: a pointer to an object
  */
-_yrt_mutex_t * _yrt_ensure_monitor (void* object);
+_yrt_mutex_t * _ensure_monitor (void* object);
 
 /**
  * Lock a mutex in an atomic block
@@ -239,7 +239,7 @@ void _yrt_atomic_monitor_exit (void * lock);
 /**
  * Initialize global monitor mutexes
  */
-void _yrt_atomic_init ();
+void _atomic_init ();
 
 /**
  * fork() the calling process, quiescing the GC around the call (GC_atfork_prepare/parent/child)

--- a/rt/except/exception.c
+++ b/rt/except/exception.c
@@ -15,7 +15,7 @@ _yrt_exc_thread_stack_t global_stack;
 
 pthread_mutex_t _yrt_exc_mutex;
 
-void _yrt_exc_init () {
+void _exc_init () {
     _yrt_thread_mutex_init (&_yrt_exc_mutex, NULL);
     global_stack.id = pthread_self ();
     global_stack.next = NULL;
@@ -35,7 +35,7 @@ void _yrt_exc_init () {
 /**
  * @returns: the stack for the current thread NULL if none
  */
-_yrt_exc_thread_stack_t* _yrt_exc_get_thread_stack_current (pthread_t id, _yrt_exc_thread_stack_t * current) {
+_yrt_exc_thread_stack_t* _exc_get_thread_stack_current (pthread_t id, _yrt_exc_thread_stack_t * current) {
     while (current != NULL) {
         if (pthread_equal (current-> id, id)) return current;
         current = current-> next;
@@ -48,10 +48,10 @@ _yrt_exc_thread_stack_t* _yrt_exc_get_thread_stack_current (pthread_t id, _yrt_e
 /**
  * Insert a new exception stack into the thread stack
  */
-_yrt_exc_thread_stack_t* _yrt_exc_insert_thread (pthread_t id) {
+_yrt_exc_thread_stack_t* _exc_insert_thread (pthread_t id) {
     _yrt_exc_thread_stack_t * head = (_yrt_exc_thread_stack_t*) __builtin_calloc (sizeof (_yrt_exc_thread_stack_t), 1);
     if (head == NULL) {
-        _yrt_exc_terminate ("out of memory\n", __FILE__, __FUNCTION__, __LINE__);
+        _exc_terminate ("out of memory\n", __FILE__, __FUNCTION__, __LINE__);
     }
 
     head-> id = id;
@@ -75,7 +75,7 @@ _yrt_exc_thread_stack_t* _yrt_exc_insert_thread (pthread_t id) {
 /**
  * Remove the exception stack for the thread 'id'
  */
-void _yrt_exc_remove_thread (_yrt_exc_thread_stack_t* stack) {
+void _exc_remove_thread (_yrt_exc_thread_stack_t* stack) {
     if (stack != &global_stack) {
         _yrt_thread_mutex_lock (&_yrt_exc_mutex);
         // we have to look up the thread in the list as it could have changed since insertion
@@ -98,13 +98,13 @@ void _yrt_exc_remove_thread (_yrt_exc_thread_stack_t* stack) {
  * Get the exception stack of the current thread
  * Insert a new one if not found
  */
-_yrt_exc_thread_stack_t* _yrt_exc_get_thread_stack (pthread_t id) {
+_yrt_exc_thread_stack_t* _exc_get_thread_stack (pthread_t id) {
     _yrt_thread_mutex_lock (&_yrt_exc_mutex);
-    _yrt_exc_thread_stack_t* got = _yrt_exc_get_thread_stack_current (id, &global_stack);
+    _yrt_exc_thread_stack_t* got = _exc_get_thread_stack_current (id, &global_stack);
     _yrt_thread_mutex_unlock (&_yrt_exc_mutex);
 
     if (got == NULL) {
-        return _yrt_exc_insert_thread (id);
+        return _exc_insert_thread (id);
     }
 
     return got;
@@ -113,12 +113,12 @@ _yrt_exc_thread_stack_t* _yrt_exc_get_thread_stack (pthread_t id) {
 /**
  * Allocate and init an _yrt_exception_header_
  */
-_yrt_exception_header_t* _yrt_exc_create_header (void* object, _yrt_exc_thread_stack_t* stack) {
+_yrt_exception_header_t* _exc_create_header (void* object, _yrt_exc_thread_stack_t* stack) {
     _yrt_exception_header_t* eh = &(stack-> ehstorage);
     if (eh-> object != NULL) { // pre allocate already in use
         eh = (_yrt_exception_header_t*) __builtin_calloc (sizeof (_yrt_exception_header_t), 1);
         if (!eh) {
-            _yrt_exc_terminate ("out of memory\n", __FILE__, __FUNCTION__, __LINE__);
+            _exc_terminate ("out of memory\n", __FILE__, __FUNCTION__, __LINE__);
         }
     }
 
@@ -131,21 +131,21 @@ _yrt_exception_header_t* _yrt_exc_create_header (void* object, _yrt_exc_thread_s
 /**
  * Free exception created by create ()
  */
-void _yrt_exc_free_header (_yrt_exception_header_t* head, _yrt_exc_thread_stack_t* stack) {
+void _exc_free_header (_yrt_exception_header_t* head, _yrt_exc_thread_stack_t* stack) {
     memset (head, 0, sizeof (_yrt_exception_header_t));
     if (head != &(stack-> ehstorage)) {
         __builtin_free (head);
     }
 
     if (stack-> stack == NULL) {
-        _yrt_exc_remove_thread (stack);
+        _exc_remove_thread (stack);
     }
 }
 
 /**
  * Push the exception header onto the stack
  */
-void _yrt_exc_push (_yrt_exception_header_t* e, _yrt_exc_thread_stack_t * stack) {
+void _exc_push (_yrt_exception_header_t* e, _yrt_exc_thread_stack_t * stack) {
     e-> next = stack-> stack;
     stack-> stack = e;
 }
@@ -153,7 +153,7 @@ void _yrt_exc_push (_yrt_exception_header_t* e, _yrt_exc_thread_stack_t * stack)
 /**
  * Pop the last pushed exception of the stack
  */
-_yrt_exception_header_t* _yrt_exc_pop (_yrt_exc_thread_stack_t* stack) {
+_yrt_exception_header_t* _exc_pop (_yrt_exc_thread_stack_t* stack) {
     _yrt_exception_header_t* eh = stack-> stack;
     stack-> stack = eh-> next;
     return eh;
@@ -169,7 +169,7 @@ _yrt_exception_header_t* _yrt_exc_pop (_yrt_exc_thread_stack_t* stack) {
  */
 
 
-void _yrt_exc_panic_exception (_yrt_exception_header_t* eh)
+void _exc_panic_exception (_yrt_exception_header_t* eh)
 {
     fprintf (stderr, "Panic in file \"%s\", at line %lu", eh-> file, eh-> line);
     fprintf (stderr, ", in function \"%s\" !!! \n", eh-> function);
@@ -181,7 +181,7 @@ void _yrt_exc_panic_exception (_yrt_exception_header_t* eh)
     abort ();
 }
 
-_yrt_exception_header_t* _yrt_to_exception_header (struct _Unwind_Exception* exc) {
+_yrt_exception_header_t* _to_exception_header (struct _Unwind_Exception* exc) {
     // the unwindHeader is the first field of the _yrt_exception_header_
     // So it has the same address
     return (_yrt_exception_header_t*) ((void*) exc);
@@ -191,20 +191,20 @@ _yrt_exception_header_t* _yrt_to_exception_header (struct _Unwind_Exception* exc
 /**
  * Called by unwinder when exception object needs destruction outside of ymir runtime
  */
-void _yrt_exc_exception_cleanup (_Unwind_Reason_Code code, struct _Unwind_Exception* exc) {
-    _yrt_exception_header_t* eh = _yrt_to_exception_header (exc);
+void _exc_exception_cleanup (_Unwind_Reason_Code code, struct _Unwind_Exception* exc) {
+    _yrt_exception_header_t* eh = _to_exception_header (exc);
     if (code != _URC_FOREIGN_EXCEPTION_CAUGHT && code != _URC_NO_REASON) {
-        _yrt_exc_panic_exception (eh);
+        _exc_panic_exception (eh);
     }
 
-    _yrt_exc_thread_stack_t* stack = _yrt_exc_get_thread_stack (eh-> thread_id);
-    _yrt_exc_free_header (eh, stack);
+    _yrt_exc_thread_stack_t* stack = _exc_get_thread_stack (eh-> thread_id);
+    _exc_free_header (eh, stack);
 }
 
 
 void _yrt_exc_throw (char *file, char *function, unsigned line, void* data) {
-    _yrt_exc_thread_stack_t* stack = _yrt_exc_get_thread_stack (pthread_self ());
-    _yrt_exception_header_t* eh = _yrt_exc_create_header (data, stack);
+    _yrt_exc_thread_stack_t* stack = _exc_get_thread_stack (pthread_self ());
+    _yrt_exception_header_t* eh = _exc_create_header (data, stack);
 
     eh-> file = file;
     eh-> function = function;
@@ -212,26 +212,26 @@ void _yrt_exc_throw (char *file, char *function, unsigned line, void* data) {
 
 
     // Add to thrown exception stack
-    _yrt_exc_push (eh, stack);
+    _exc_push (eh, stack);
 
-    eh-> unwindHeader.exception_cleanup = &_yrt_exc_exception_cleanup;
+    eh-> unwindHeader.exception_cleanup = &_exc_exception_cleanup;
     _Unwind_Reason_Code r = _Unwind_RaiseException (&eh-> unwindHeader);
 
     if (r == _URC_END_OF_STACK) {
-        _yrt_exc_panic_exception (eh);
+        _exc_panic_exception (eh);
     }
 
-    _yrt_exc_terminate ("unwind error ", __FILE__, __FUNCTION__, __LINE__);
+    _exc_terminate ("unwind error ", __FILE__, __FUNCTION__, __LINE__);
 }
 
 void* _yrt_exc_begin_catch (struct _Unwind_Exception* unwindHeader) {
-    _yrt_exc_thread_stack_t* stack = _yrt_exc_get_thread_stack (pthread_self ());
-    _yrt_exception_header_t* header = _yrt_to_exception_header (unwindHeader);
+    _yrt_exc_thread_stack_t* stack = _exc_get_thread_stack (pthread_self ());
+    _yrt_exception_header_t* header = _to_exception_header (unwindHeader);
     void* object = header-> object;
 
     // Something went wront when stacking headers
-    if (header != _yrt_exc_pop (stack)) {
-        _yrt_exc_terminate ("Catch error", __FILE__, __FUNCTION__, __LINE__);
+    if (header != _exc_pop (stack)) {
+        _exc_terminate ("Catch error", __FILE__, __FUNCTION__, __LINE__);
     }
 
     // The exception handling is complete

--- a/rt/except/exception.h
+++ b/rt/except/exception.h
@@ -74,49 +74,49 @@ typedef struct _yrt_exc_thread_stack_t {
 /**
  * Initialize exception system
  */
-void _yrt_exc_init ();
+void _exc_init ();
 
 /**
  * @returns: the stack for the current thread NULL if none
  */
-_yrt_exc_thread_stack_t* _yrt_exc_get_thread_stack_current (pthread_t id, _yrt_exc_thread_stack_t * current);
+_yrt_exc_thread_stack_t* _exc_get_thread_stack_current (pthread_t id, _yrt_exc_thread_stack_t * current);
 
 /**
  * Insert a new exception stack into the thread stack
  */
-_yrt_exc_thread_stack_t* _yrt_exc_insert_thread (pthread_t id);
+_yrt_exc_thread_stack_t* _exc_insert_thread (pthread_t id);
 
 /**
  * Remove the exception stack for the thread 'id'
  */
-void _yrt_exc_remove_thread (_yrt_exc_thread_stack_t* stack);
+void _exc_remove_thread (_yrt_exc_thread_stack_t* stack);
 
 
 /**
  * Get the exception stack of the current thread
  * Insert a new one if not found
  */
-_yrt_exc_thread_stack_t* _yrt_exc_get_thread_stack (pthread_t id);
+_yrt_exc_thread_stack_t* _exc_get_thread_stack (pthread_t id);
 
 /**
  * Allocate and init an _yrt_exception_header_
  */
-_yrt_exception_header_t* _yrt_exc_create_header (void* object, _yrt_exc_thread_stack_t* stack);
+_yrt_exception_header_t* _exc_create_header (void* object, _yrt_exc_thread_stack_t* stack);
 
 /**
  * Free exception created by create ()
  */
-void _yrt_exc_free_header (_yrt_exception_header_t* head, _yrt_exc_thread_stack_t* stack);
+void _exc_free_header (_yrt_exception_header_t* head, _yrt_exc_thread_stack_t* stack);
 
 /**
  * Push the exception header onto the stack
  */
-void _yrt_exc_push (_yrt_exception_header_t* e, _yrt_exc_thread_stack_t * stack);
+void _exc_push (_yrt_exception_header_t* e, _yrt_exc_thread_stack_t * stack);
 
 /**
  * Pop the last pushed exception of the stack
  */
-_yrt_exception_header_t* _yrt_exc_pop (_yrt_exc_thread_stack_t* stack);
+_yrt_exception_header_t* _exc_pop (_yrt_exc_thread_stack_t* stack);
 
 
 /**
@@ -130,18 +130,18 @@ _yrt_exception_header_t* _yrt_exc_pop (_yrt_exc_thread_stack_t* stack);
 /**
  * Terminate the program due to a uncaught exception error
  */
-void _yrt_exc_panic_exception (_yrt_exception_header_t* eh);
+void _exc_panic_exception (_yrt_exception_header_t* eh);
 
 /**
  * Cast an _Unwind_Exception into a _yrt_exception header
  */
-_yrt_exception_header_t* _yrt_to_exception_header (struct _Unwind_Exception* exc);
+_yrt_exception_header_t* _to_exception_header (struct _Unwind_Exception* exc);
 
 
 /**
  * Called by unwinder when exception object needs destruction outside of ymir runtime
  */
-void _yrt_exc_exception_cleanup (_Unwind_Reason_Code code, struct _Unwind_Exception* exc);
+void _exc_exception_cleanup (_Unwind_Reason_Code code, struct _Unwind_Exception* exc);
 
 
 /**

--- a/rt/except/panic.c
+++ b/rt/except/panic.c
@@ -12,7 +12,7 @@
 /**
  * Terminate the program due to a irrecoverable error
  */
-void _yrt_exc_terminate (const char * msg, const char * file, const char * func, unsigned int line) {
+void _exc_terminate (const char * msg, const char * file, const char * func, unsigned int line) {
     static char terminating = 0;
     if (terminating) {
         fprintf (stderr, "terminating called recursively\n");
@@ -46,7 +46,7 @@ void _yrt_exc_panic (const char* file, const char * function, unsigned int line)
     abort ();
 }
 
-void _yrt_exc_panic_seg_fault () {
+void _exc_panic_seg_fault () {
     fprintf (stderr, "Segfault - ");
     _yrt_slice_t trace = _yrt_exc_resolve_stack_trace (_yrt_exc_get_stack_trace ());
     if (trace.len != 0) {

--- a/rt/except/panic.h
+++ b/rt/except/panic.h
@@ -4,7 +4,7 @@
 /**
  * Terminate the program due to a irrecoverable error with an error message
  */
-void _yrt_exc_terminate (const char * msg, const char * file, const char * func, unsigned int line);
+void _exc_terminate (const char * msg, const char * file, const char * func, unsigned int line);
 
 /**
  * Terminate the program with a panic signal
@@ -19,6 +19,6 @@ void _yrt_exc_panic_no_trace ();
 /**
  * Terminate the program with a panic signal without computing the stack trace
  */
-void _yrt_exc_panic_seg_fault ();
+void _exc_panic_seg_fault ();
 
 #endif // PANIC_H_

--- a/rt/except/personnality.c
+++ b/rt/except/personnality.c
@@ -23,23 +23,23 @@
 
 #define DW_EH_PE_indirect 0x80
 
-void _yrt_exc_save (struct _Unwind_Exception* unwindHeader, int handler, const char* lsda, _Unwind_Ptr landingPad, _Unwind_Word cfa) {
-    _yrt_exception_header_t * eh = _yrt_to_exception_header (unwindHeader);
+void _exc_save (struct _Unwind_Exception* unwindHeader, int handler, const char* lsda, _Unwind_Ptr landingPad, _Unwind_Word cfa) {
+    _yrt_exception_header_t * eh = _to_exception_header (unwindHeader);
     eh-> lsda = lsda;
     eh-> handler = handler;
     eh-> landingPad = landingPad;
     eh-> cfa = cfa;
 }
 
-void _yrt_exc_restore (struct _Unwind_Exception* unwindHeader, int * handler, const char** lsda, _Unwind_Ptr* landingPad, _Unwind_Word* cfa) {
-    _yrt_exception_header_t * eh = _yrt_to_exception_header (unwindHeader);
+void _exc_restore (struct _Unwind_Exception* unwindHeader, int * handler, const char** lsda, _Unwind_Ptr* landingPad, _Unwind_Word* cfa) {
+    _yrt_exception_header_t * eh = _to_exception_header (unwindHeader);
     *lsda = eh-> lsda;
     *handler = eh-> handler;
     *landingPad = eh-> landingPad ;
     *cfa = eh-> cfa;
 }
 
-uint32_t _yrt_exc_size_of_encoded_value (uint8_t encoding) {
+uint32_t _exc_size_of_encoded_value (uint8_t encoding) {
     if (encoding == DW_EH_PE_omit) return 0;
 
     switch (encoding & 0x07) {
@@ -52,11 +52,11 @@ uint32_t _yrt_exc_size_of_encoded_value (uint8_t encoding) {
     case DW_EH_PE_udata8 :
         return 8;
     default :
-        _yrt_exc_terminate ("reading encoded", __FILE__, __FUNCTION__, __LINE__);
+        _exc_terminate ("reading encoded", __FILE__, __FUNCTION__, __LINE__);
     }
 }
 
-_Unwind_Ptr _yrt_exc_base_of_encoded_value (uint8_t encoding, struct _Unwind_Context* context) {
+_Unwind_Ptr _exc_base_of_encoded_value (uint8_t encoding, struct _Unwind_Context* context) {
     if (encoding == DW_EH_PE_omit) return 0;
 
     switch (encoding & 0x70) {
@@ -71,11 +71,11 @@ _Unwind_Ptr _yrt_exc_base_of_encoded_value (uint8_t encoding, struct _Unwind_Con
     case DW_EH_PE_funcrel:
         return _Unwind_GetRegionStart (context);
     default :
-        _yrt_exc_terminate ("reading encoded", __FILE__, __FUNCTION__, __LINE__);
+        _exc_terminate ("reading encoded", __FILE__, __FUNCTION__, __LINE__);
     }
 }
 
-_Unwind_Internal_Ptr _yrt_exc_read_uleb128 (const char** pref) {
+_Unwind_Internal_Ptr _exc_read_uleb128 (const char** pref) {
     _Unwind_Internal_Ptr result = 0;
     uint32_t shift = 0;
 
@@ -93,7 +93,7 @@ _Unwind_Internal_Ptr _yrt_exc_read_uleb128 (const char** pref) {
     return result;
 }
 
-_Unwind_Internal_Ptr _yrt_exc_read_sleb128 (const char** pref) {
+_Unwind_Internal_Ptr _exc_read_sleb128 (const char** pref) {
     _Unwind_Internal_Ptr result = 0;
     uint32_t shift = 0;
     uint8_t b = 0;
@@ -117,13 +117,13 @@ _Unwind_Internal_Ptr _yrt_exc_read_sleb128 (const char** pref) {
 }
 
 
-void _yrt_exc_read_unaligned (const char** p, void* data, size_t size) {
+void _exc_read_unaligned (const char** p, void* data, size_t size) {
     memcpy (data, *p, size);
     *p += size;
 }
 
 
-_Unwind_Ptr _yrt_exc_read_encoded_value_with_base (uint8_t encoding, _Unwind_Ptr base, const char** p) {
+_Unwind_Ptr _exc_read_encoded_value_with_base (uint8_t encoding, _Unwind_Ptr base, const char** p) {
     const char** psave = p;
     _Unwind_Internal_Ptr result;
 
@@ -135,18 +135,18 @@ _Unwind_Ptr _yrt_exc_read_encoded_value_with_base (uint8_t encoding, _Unwind_Ptr
     } else {
         switch (encoding & 0x0f) {
         case DW_EH_PE_uleb128 :
-            result = (_Unwind_Internal_Ptr) (_yrt_exc_read_uleb128 (p));
+            result = (_Unwind_Internal_Ptr) (_exc_read_uleb128 (p));
             break;
 
         case DW_EH_PE_sleb128 :
-            result = (_Unwind_Internal_Ptr) (_yrt_exc_read_sleb128 (p));
+            result = (_Unwind_Internal_Ptr) (_exc_read_sleb128 (p));
             break;
 
         case DW_EH_PE_udata2 :
         case DW_EH_PE_sdata2 :
         {
             uint16_t x;
-            _yrt_exc_read_unaligned (p, &x, sizeof (uint16_t));
+            _exc_read_unaligned (p, &x, sizeof (uint16_t));
             result = (_Unwind_Internal_Ptr) (x);
             break;
         }
@@ -154,7 +154,7 @@ _Unwind_Ptr _yrt_exc_read_encoded_value_with_base (uint8_t encoding, _Unwind_Ptr
         case DW_EH_PE_sdata4 :
         {
             uint32_t x;
-            _yrt_exc_read_unaligned (p, &x, sizeof (uint32_t));
+            _exc_read_unaligned (p, &x, sizeof (uint32_t));
             result = (_Unwind_Internal_Ptr) (x);
             break;
         }
@@ -162,19 +162,19 @@ _Unwind_Ptr _yrt_exc_read_encoded_value_with_base (uint8_t encoding, _Unwind_Ptr
         case DW_EH_PE_sdata8 :
         {
             uint64_t x;
-            _yrt_exc_read_unaligned (p, &x, sizeof (uint64_t));
+            _exc_read_unaligned (p, &x, sizeof (uint64_t));
             result = (_Unwind_Internal_Ptr) (x);
             break;
         }
         case DW_EH_PE_absptr :
         {
             size_t x;
-            _yrt_exc_read_unaligned (p, &x, sizeof (size_t));
+            _exc_read_unaligned (p, &x, sizeof (size_t));
             result = (_Unwind_Internal_Ptr) (x);
             break;
         }
         default :
-            _yrt_exc_terminate ("reading encoded", __FILE__, __FUNCTION__, __LINE__);
+            _exc_terminate ("reading encoded", __FILE__, __FUNCTION__, __LINE__);
         }
     }
 
@@ -190,12 +190,12 @@ _Unwind_Ptr _yrt_exc_read_encoded_value_with_base (uint8_t encoding, _Unwind_Ptr
     return result;
 }
 
-_Unwind_Ptr _yrt_exc_read_encoded_value (struct _Unwind_Context* context, uint8_t encoding, const char** p) {
-    _Unwind_Ptr base = _yrt_exc_base_of_encoded_value (encoding, context);
-    return _yrt_exc_read_encoded_value_with_base (encoding, base, p);
+_Unwind_Ptr _exc_read_encoded_value (struct _Unwind_Context* context, uint8_t encoding, const char** p) {
+    _Unwind_Ptr base = _exc_base_of_encoded_value (encoding, context);
+    return _exc_read_encoded_value_with_base (encoding, base, p);
 }
 
-int32_t _yrt_exc_action_table_lookup (_Unwind_Action actions,
+int32_t _exc_action_table_lookup (_Unwind_Action actions,
                                   struct _Unwind_Exception* unwindHeader,
                                   const char* actionRecord,
                                   _Unwind_Ptr TTypeBase,
@@ -206,19 +206,19 @@ int32_t _yrt_exc_action_table_lookup (_Unwind_Action actions,
 {
     while (1) {
         const char* ap = actionRecord;
-        _Unwind_Internal_Ptr ARFilter = _yrt_exc_read_sleb128 (&ap);
+        _Unwind_Internal_Ptr ARFilter = _exc_read_sleb128 (&ap);
         const char* apn = ap;
-        _Unwind_Internal_Ptr ARDisp = _yrt_exc_read_sleb128 (&ap);
+        _Unwind_Internal_Ptr ARDisp = _exc_read_sleb128 (&ap);
 
         if (ARFilter == 0) {
             *saw_cleanup = 1;
         } else if (actions & _UA_FORCE_UNWIND) {}
         else if (ARFilter > 0) {
-            size_t encodedSize = _yrt_exc_size_of_encoded_value (TTypeEncoding);
+            size_t encodedSize = _exc_size_of_encoded_value (TTypeEncoding);
 
             const char* tp = TType - ARFilter * encodedSize;
 
-            _Unwind_Ptr entry = _yrt_exc_read_encoded_value_with_base (TTypeEncoding, TTypeBase, &tp);
+            _Unwind_Ptr entry = _exc_read_encoded_value_with_base (TTypeEncoding, TTypeBase, &tp);
             *saw_handler = 1;
 
             return ARFilter;
@@ -232,7 +232,7 @@ int32_t _yrt_exc_action_table_lookup (_Unwind_Action actions,
 }
 
 
-_Unwind_Reason_Code _yrt_exc_scan_lsda (const char* lsda,
+_Unwind_Reason_Code _exc_scan_lsda (const char* lsda,
                                         _Unwind_Action actions,
                                         struct _Unwind_Exception* unwindHeader,
                                         struct _Unwind_Context* context,
@@ -249,22 +249,22 @@ _Unwind_Reason_Code _yrt_exc_scan_lsda (const char* lsda,
     _Unwind_Ptr LPStart = 0;
 
     if (LPStartEncoding != DW_EH_PE_omit) {
-        LPStart = _yrt_exc_read_encoded_value (context, LPStartEncoding, &p);
+        LPStart = _exc_read_encoded_value (context, LPStartEncoding, &p);
     } else LPStart = start;
 
     uint8_t TTypeEncoding = *p++;
     const uint8_t* TType = NULL;
 
     if (TTypeEncoding != DW_EH_PE_omit) {
-        _Unwind_Internal_Ptr TTBase = _yrt_exc_read_uleb128 (&p);
+        _Unwind_Internal_Ptr TTBase = _exc_read_uleb128 (&p);
         TType = p + TTBase;
     }
 
     uint8_t CSEncoding = *p++;
-    _Unwind_Internal_Ptr CSTableSize = _yrt_exc_read_uleb128 (&p);
+    _Unwind_Internal_Ptr CSTableSize = _exc_read_uleb128 (&p);
     const char* actionTable = p + CSTableSize;
 
-    _Unwind_Internal_Ptr TTypeBase = _yrt_exc_base_of_encoded_value (TTypeEncoding, context);
+    _Unwind_Internal_Ptr TTypeBase = _exc_base_of_encoded_value (TTypeEncoding, context);
 
     int ip_before_insn;
     _Unwind_Internal_Ptr ip = _Unwind_GetIPInfo (context, &ip_before_insn);
@@ -275,10 +275,10 @@ _Unwind_Reason_Code _yrt_exc_scan_lsda (const char* lsda,
     const uint8_t * actionRecord = NULL;
 
     while (p < actionTable) {
-        _Unwind_Internal_Ptr CSStart = _yrt_exc_read_encoded_value (NULL, CSEncoding, &p);
-        _Unwind_Internal_Ptr CSLen = _yrt_exc_read_encoded_value (NULL, CSEncoding, &p);
-        _Unwind_Internal_Ptr CSLandingPad = _yrt_exc_read_encoded_value (NULL, CSEncoding, &p);
-        _Unwind_Internal_Ptr CSAction = _yrt_exc_read_uleb128 (&p);
+        _Unwind_Internal_Ptr CSStart = _exc_read_encoded_value (NULL, CSEncoding, &p);
+        _Unwind_Internal_Ptr CSLen = _exc_read_encoded_value (NULL, CSEncoding, &p);
+        _Unwind_Internal_Ptr CSLandingPad = _exc_read_encoded_value (NULL, CSEncoding, &p);
+        _Unwind_Internal_Ptr CSAction = _exc_read_uleb128 (&p);
 
         if (ip < start + CSStart) {
             p = actionTable;
@@ -293,7 +293,7 @@ _Unwind_Reason_Code _yrt_exc_scan_lsda (const char* lsda,
     } else if (actionRecord == NULL) {
         saw_cleanup = 1;
     } else {
-        *handler = _yrt_exc_action_table_lookup (actions, unwindHeader, actionRecord,
+        *handler = _exc_action_table_lookup (actions, unwindHeader, actionRecord,
                                                  TTypeBase, TType, TTypeEncoding,
                                                  &saw_handler, &saw_cleanup);
     }
@@ -305,7 +305,7 @@ _Unwind_Reason_Code _yrt_exc_scan_lsda (const char* lsda,
     if (actions & _UA_SEARCH_PHASE) {
         if (!saw_handler) return _URC_CONTINUE_UNWIND;
 
-        _yrt_exc_save (unwindHeader, *handler, lsda, *landingPad, cfa);
+        _exc_save (unwindHeader, *handler, lsda, *landingPad, cfa);
 
         return _URC_HANDLER_FOUND;
     }
@@ -316,7 +316,7 @@ _Unwind_Reason_Code _yrt_exc_scan_lsda (const char* lsda,
 
 
 
-_Unwind_Reason_Code _yrt_exc_personality (_Unwind_Action actions,
+_Unwind_Reason_Code _exc_personality (_Unwind_Action actions,
                                           _Unwind_Exception_Class excClass,
                                           struct _Unwind_Exception* unwindHeader,
                                           struct _Unwind_Context* context)
@@ -328,15 +328,15 @@ _Unwind_Reason_Code _yrt_exc_personality (_Unwind_Action actions,
 
 
     if (actions == (_UA_CLEANUP_PHASE | _UA_HANDLER_FRAME)) {
-        _yrt_exc_restore (unwindHeader, &handler, &lsda, &landingPad, &cfa);
+        _exc_restore (unwindHeader, &handler, &lsda, &landingPad, &cfa);
         if (landingPad == 0) {
-            _yrt_exc_terminate ("unwind error", __FILE__, __FUNCTION__, __LINE__);
+            _exc_terminate ("unwind error", __FILE__, __FUNCTION__, __LINE__);
         }
     } else {
         lsda = _Unwind_GetLanguageSpecificData (context);
         cfa = _Unwind_GetCFA (context);
 
-        char result = _yrt_exc_scan_lsda (lsda, actions, unwindHeader, context, cfa, &landingPad, &handler);
+        char result = _exc_scan_lsda (lsda, actions, unwindHeader, context, cfa, &landingPad, &handler);
 
         if (result) return result;
     }
@@ -365,7 +365,7 @@ _Unwind_Reason_Code __gyc_personality_v0 (int iversion,
         return _URC_FATAL_PHASE1_ERROR;
     }
 
-    return _yrt_exc_personality (actions, excClass, unwindHeader, context);
+    return _exc_personality (actions, excClass, unwindHeader, context);
 }
 
 #ifdef _WIN32

--- a/rt/except/personnality.h
+++ b/rt/except/personnality.h
@@ -3,23 +3,23 @@
 
 #include <rt/except/exception.h>
 
-void _yrt_exc_save (struct _Unwind_Exception* unwindHeader, int handler, const char* lsda, _Unwind_Ptr landingPad, _Unwind_Word cfa);
+void _exc_save (struct _Unwind_Exception* unwindHeader, int handler, const char* lsda, _Unwind_Ptr landingPad, _Unwind_Word cfa);
 
-void _yrt_exc_restore (struct _Unwind_Exception* unwindHeader, int * handler, const char** lsda, _Unwind_Ptr* landingPad, _Unwind_Word* cfa);
+void _exc_restore (struct _Unwind_Exception* unwindHeader, int * handler, const char** lsda, _Unwind_Ptr* landingPad, _Unwind_Word* cfa);
 
-uint32_t _yrt_exc_size_of_encoded_value (uint8_t encoding);
+uint32_t _exc_size_of_encoded_value (uint8_t encoding);
 
-_Unwind_Ptr _yrt_exc_base_of_encoded_value (uint8_t encoding, struct _Unwind_Context* context);
+_Unwind_Ptr _exc_base_of_encoded_value (uint8_t encoding, struct _Unwind_Context* context);
 
-_Unwind_Internal_Ptr _yrt_exc_read_uleb128 (const char** pref);
+_Unwind_Internal_Ptr _exc_read_uleb128 (const char** pref);
 
-_Unwind_Internal_Ptr _yrt_exc_read_sleb128 (const char** pref);
+_Unwind_Internal_Ptr _exc_read_sleb128 (const char** pref);
 
-void _yrt_exc_read_unaligned (const char** p, void* data, size_t size);
+void _exc_read_unaligned (const char** p, void* data, size_t size);
 
-_Unwind_Ptr _yrt_exc_read_encoded_value (struct _Unwind_Context* context, uint8_t encoding, const char** p);
+_Unwind_Ptr _exc_read_encoded_value (struct _Unwind_Context* context, uint8_t encoding, const char** p);
 
-int32_t _yrt_exc_action_table_lookup (_Unwind_Action actions,
+int32_t _exc_action_table_lookup (_Unwind_Action actions,
 									  struct _Unwind_Exception* unwindHeader,
 									  const char* actionRecord,
 									  _Unwind_Ptr TTypeBase,
@@ -28,7 +28,7 @@ int32_t _yrt_exc_action_table_lookup (_Unwind_Action actions,
 									  uint8_t * saw_handler,
 									  uint8_t * saw_cleanup);
 
-_Unwind_Reason_Code _yrt_exc_scan_lsda (const char* lsda,
+_Unwind_Reason_Code _exc_scan_lsda (const char* lsda,
                                         _Unwind_Action actions,
                                         struct _Unwind_Exception* unwindHeader,
                                         struct _Unwind_Context* context,
@@ -39,7 +39,7 @@ _Unwind_Reason_Code _yrt_exc_scan_lsda (const char* lsda,
 /**
  * Personality called when unwinding
  */
-_Unwind_Reason_Code _yrt_exc_personality (_Unwind_Action actions,
+_Unwind_Reason_Code _exc_personality (_Unwind_Action actions,
 										  _Unwind_Exception_Class exceptionClass,
 										  struct _Unwind_Exception* unwindHeader,
 										  struct _Unwind_Context* context);

--- a/rt/except/stacktrace.c
+++ b/rt/except/stacktrace.c
@@ -26,7 +26,7 @@ int __YRT_MAXIMUM_TRACE_LEN__ = 128;
 
 #define PATH_MAX 255
 
-char* _yrt_resolve_path (const char * filename, char * resolved, int size) {
+char* _resolve_path (const char * filename, char * resolved, int size) {
     int len_f = strlen (filename);
     if (access (filename, F_OK) == 0) {
         memcpy (resolved, filename, len_f);
@@ -80,7 +80,7 @@ _yrt_slice_t _yrt_exc_resolve_stack_trace (_yrt_slice_t syms) {
         filename [p] = '\0';
 
         char resolved [PATH_MAX];
-        char* succ = _yrt_resolve_path (filename, resolved, PATH_MAX);
+        char* succ = _resolve_path (filename, resolved, PATH_MAX);
 
         void * sym = ((void**) syms.data)[i];
         struct _yrt_reflect_symbol_t ref_sym;
@@ -107,7 +107,7 @@ _yrt_slice_t _yrt_exc_resolve_stack_trace (_yrt_slice_t syms) {
 
             int need_break = 0;
             if (ref_sym.name.data != NULL) {
-                _yrt_slice_t name = _yrt_demangle_symbol (ref_sym.name.data, ref_sym.name.len);
+                _yrt_slice_t name = _demangle_symbol (ref_sym.name.data, ref_sym.name.len);
 
                 tmp = str_create (" in function \e[33m");
                 _yrt_append_slice (&result, &tmp, sizeof (uint8_t));

--- a/rt/except/stacktrace.h
+++ b/rt/except/stacktrace.h
@@ -18,7 +18,7 @@ extern int __YRT_TEST_CODE__;
  * @returns:
  *    - resolved: the path to the file resolved
  */
-char* _yrt_resolve_path (const char* filename, char* resolved, int size);
+char* _resolve_path (const char* filename, char* resolved, int size);
 
 #endif
 

--- a/rt/memory/alloc.c
+++ b/rt/memory/alloc.c
@@ -7,7 +7,7 @@
 #include <string.h>
 
 
-uint64_t _yrt_next_pow2 (uint64_t x) {
+uint64_t _next_pow2 (uint64_t x) {
 	if (x == 1) return 1;
 	else {
 		return 1 << (64 - __builtin_clzl (x - 1));
@@ -20,7 +20,7 @@ void _yrt_alloc_slice_no_set (_yrt_slice_t * result, uint64_t len, uint64_t size
 		return;
 	}
 
-	size_t allocLen = _yrt_next_pow2 (len);
+	size_t allocLen = _next_pow2 (len);
 	size_t allocSize = allocLen * size;
 	uint8_t* x = (uint8_t*) GC_malloc (allocSize + sizeof (_yrt_slice_blk_info_t));
 	_yrt_slice_blk_info_t * blk = (_yrt_slice_blk_info_t*) (x);

--- a/rt/memory/alloc.h
+++ b/rt/memory/alloc.h
@@ -17,7 +17,7 @@
  *   - x: an arbitrary number
  * @returns: the closest power of two to 'x'
  *  */
-uint64_t _yrt_next_pow2 (uint64_t x);
+uint64_t _next_pow2 (uint64_t x);
 
 /**
  * Allocate a new array and set the values of each element

--- a/rt/memory/classes.c
+++ b/rt/memory/classes.c
@@ -1,6 +1,6 @@
 #include <rt/memory/classes.h>
 
-void _yrt_destruct_class (GC_PTR obj, GC_PTR x) {
+void _destruct_class (GC_PTR obj, GC_PTR x) {
     void* vtable = *((void**)obj); // vtable
     // the second element is the destructor
     void(*__dtor) (void*) = *(void(**)(void*)) ((void**) vtable + 1);
@@ -23,7 +23,7 @@ void* _yrt_alloc_class (void* vtable) {
         // no_order: a class reachable from a reference cycle must still be
         // destructed. Ordered finalization refuses to finalize cycles (warning
         // "Finalization cycle involving 0x...", and the __dtor never runs).
-        GC_register_finalizer_no_order (cl, _yrt_destruct_class, NULL, NULL, NULL);
+        GC_register_finalizer_no_order (cl, _destruct_class, NULL, NULL, NULL);
     }
 
     return cl;

--- a/rt/memory/classes.h
+++ b/rt/memory/classes.h
@@ -24,6 +24,6 @@ void* _yrt_alloc_class (void* vtable);
 /**
  * Called when a class is destroyed by the gc
  *  */
-void _yrt_destruct_class (GC_PTR obj, GC_PTR x);
+void _destruct_class (GC_PTR obj, GC_PTR x);
 
 #endif // CLASSES_H_

--- a/rt/memory/conv.c
+++ b/rt/memory/conv.c
@@ -173,7 +173,7 @@ long double _yrt_string_to_fsize (_yrt_slice_t arr, uint8_t * succ) {
  * ====================================================================================================
  */
 
-char* _yrt_to_utf8 (unsigned int code, char chars[5], int * nb) {
+char* _to_utf8 (unsigned int code, char chars[5], int * nb) {
     if (code <= 0x7F) {
 		chars[0] = (code & 0x7F); chars[1] = '\0';
 		*nb = 1;
@@ -229,7 +229,7 @@ size_t utf8_codepoint_size (char c) {
  * ====================================================================================================
  */
 
-uint32_t _yrt_to_utf32 (char* text, size_t * byte_count) {
+uint32_t _to_utf32 (char* text, size_t * byte_count) {
     *byte_count = utf8_codepoint_size(text[0]);
 
     uint a = 0, b = 0, c = 0, d = 0;

--- a/rt/memory/conv.h
+++ b/rt/memory/conv.h
@@ -57,7 +57,7 @@ long double _yrt_string_to_fsize (_yrt_slice_t str, uint8_t * succ);
  * ====================================================================================================
  */
 
-char* _yrt_to_utf8 (uint32_t code, char chars [5], int * nb);
+char* _to_utf8 (uint32_t code, char chars [5], int * nb);
 size_t utf8_codepoint_size (char c);
 
 #endif

--- a/rt/memory/map.c
+++ b/rt/memory/map.c
@@ -183,7 +183,7 @@ void _yrt_map_fit (_yrt_map_t * mp, uint64_t newSize) {
     result.data-> loaded = 0;
     result.data-> len = 0;
 
-    _yrt_map_copy_entries (&result, mp);
+    _yrt_map_relink_entries (&result, mp);
     mp-> data-> loaded = data.loaded;
     mp-> data-> len = data.len;
     mp-> data-> cap = data.cap;
@@ -202,6 +202,26 @@ void _yrt_map_copy_entries (_yrt_map_t * result, _yrt_map_t * old) {
                 _yrt_map_insert_no_resize (result, hash, key, value);
                 head = head-> next;
             }
+        }
+    }
+}
+
+void _yrt_map_relink_entries (_yrt_map_t * result, _yrt_map_t * old) {
+    for (uint64_t i = 0 ; i < old-> data-> cap ; i++) {
+        _yrt_map_entry_t * head = old-> data-> entries [i];
+        while (head != NULL) {
+            _yrt_map_entry_t * next = head-> next;
+            uint64_t index = head-> hash % result-> data-> cap;
+
+            if (result-> data-> entries [index] == NULL) {
+                result-> data-> loaded += 1;
+            }
+
+            head-> next = result-> data-> entries [index];
+            result-> data-> entries [index] = head;
+            result-> data-> len += 1;
+
+            head = next;
         }
     }
 }

--- a/rt/memory/map.c
+++ b/rt/memory/map.c
@@ -119,7 +119,7 @@ void _map_insert_no_resize (_yrt_map_t * mp, uint64_t hash, uint8_t * key, uint8
 uint8_t _map_entry_insert (_yrt_map_content_t * data, _yrt_map_entry_t * mp, uint64_t hash, uint8_t * key, uint8_t * value) {
     _yrt_map_info_t * minfo = data-> minfo;
     uint8_t * keyEntry = ((uint8_t*) mp) + sizeof (_yrt_map_entry_t);
-    if (minfo-> cmp (key, keyEntry) == 1) {
+    if (mp-> hash == hash && minfo-> cmp (key, keyEntry) == 1) {
         uint8_t * valEntry = keyEntry + minfo-> keySize;
         memcpy (valEntry, value, minfo-> valueSize);
         return 0;
@@ -160,7 +160,7 @@ void _yrt_map_erase (_yrt_map_t * mp, uint8_t * key) {
         return;
     }
 
-    if (_map_erase_entry (&(mp-> data-> entries [index]), key, mp-> data-> minfo) == 1) {
+    if (_map_erase_entry (&(mp-> data-> entries [index]), hash, key, mp-> data-> minfo) == 1) {
         mp-> data-> len -= 1;
     }
 
@@ -173,16 +173,16 @@ void _yrt_map_erase (_yrt_map_t * mp, uint8_t * key) {
     }
 }
 
-uint8_t _map_erase_entry (_yrt_map_entry_t ** en, uint8_t * key, _yrt_map_info_t * minfo) {
+uint8_t _map_erase_entry (_yrt_map_entry_t ** en, uint64_t hash, uint8_t * key, _yrt_map_info_t * minfo) {
     uint8_t * keyEntry = ((uint8_t*) (*en)) + sizeof (_yrt_map_entry_t);
-    if (minfo-> cmp (key, keyEntry) == 1) {
+    if ((*en)-> hash == hash && minfo-> cmp (key, keyEntry) == 1) {
         *en = (*en)-> next;
 
         return 1;
     }
 
     if ((*en)-> next != NULL) {
-        return _map_erase_entry (&(*en)-> next, key, minfo);
+        return _map_erase_entry (&(*en)-> next, hash, key, minfo);
     }
 
     return 0;
@@ -199,12 +199,12 @@ uint8_t * _yrt_map_find (_yrt_map_t * mp, uint8_t * key) {
         return NULL;
     }
 
-    return _map_find_entry (mp-> data-> entries [index], key, mp-> data-> minfo);
+    return _map_find_entry (mp-> data-> entries [index], hash, key, mp-> data-> minfo);
 }
 
-uint8_t * _map_find_entry (_yrt_map_entry_t * en, uint8_t * key, _yrt_map_info_t * minfo) {
+uint8_t * _map_find_entry (_yrt_map_entry_t * en, uint64_t hash, uint8_t * key, _yrt_map_info_t * minfo) {
     uint8_t * keyEntry = ((uint8_t*) en) + sizeof (_yrt_map_entry_t);
-    if (minfo-> cmp (key, keyEntry) == 1) {
+    if (en-> hash == hash && minfo-> cmp (key, keyEntry) == 1) {
         uint8_t * valueEntry = keyEntry + minfo-> keySize;
         return valueEntry;
     }
@@ -213,7 +213,7 @@ uint8_t * _map_find_entry (_yrt_map_entry_t * en, uint8_t * key, _yrt_map_info_t
         return NULL;
     }
 
-    return _map_find_entry (en-> next, key, minfo);
+    return _map_find_entry (en-> next, hash, key, minfo);
 }
 
 void _map_fit (_yrt_map_t * mp, uint64_t newSize) {

--- a/rt/memory/map.c
+++ b/rt/memory/map.c
@@ -10,7 +10,7 @@
 #define MAP_MAX_LOADED_FACTOR 75
 #define MAP_MIN_LOADED_FACTOR 40
 
-// Entry count of the first slab allocated for a map (see _yrt_map_entry_alloc). Each
+// Entry count of the first slab allocated for a map (see _map_entry_alloc). Each
 // subsequent slab for the same map doubles in size, up to MAP_SLAB_MAX_BYTES, so a map
 // that only ever holds a handful of entries (e.g. one JSON object) does not pay for a
 // slab sized for a map that ends up holding millions.
@@ -48,7 +48,7 @@ void _yrt_map_empty (_yrt_map_t * mp, _yrt_map_info_t * info) {
  * with slabs growing geometrically (like a vector) instead of a single fixed size,
  * so a map with few entries does not over-allocate.
  */
-static uint8_t * _yrt_map_entry_alloc (_yrt_map_content_t * data, uint64_t nodeSize) {
+static uint8_t * _map_entry_alloc (_yrt_map_content_t * data, uint64_t nodeSize) {
     uint64_t stride = (nodeSize + MAP_ENTRY_ALIGN - 1) & ~(MAP_ENTRY_ALIGN - 1);
 
     if (data-> slabCur == NULL || (uint64_t) (data-> slabEnd - data-> slabCur) < stride) {
@@ -82,37 +82,37 @@ void _yrt_dup_map (_yrt_map_t * result, _yrt_map_info_t * info, _yrt_map_t * old
     result-> data-> entries = (_yrt_map_entry_t**) GC_malloc ((old-> data-> cap) * sizeof (_yrt_map_entry_t*));
     memset (result-> data-> entries, 0, (old-> data-> cap) * sizeof (_yrt_map_entry_t*));
 
-    _yrt_map_copy_entries (result, old);
+    _map_copy_entries (result, old);
 }
 
 void _yrt_map_insert (_yrt_map_t * mp, uint8_t * key, uint8_t * value) {
     if (mp-> data-> cap == 0) {
-        _yrt_map_fit (mp, 1);
+        _map_fit (mp, 1);
     } else if ((mp-> data-> loaded * 100 / mp-> data-> cap) > MAP_MAX_LOADED_FACTOR) {
-        _yrt_map_fit (mp, _yrt_next_pow2 (mp-> data-> cap + 1));
+        _map_fit (mp, _next_pow2 (mp-> data-> cap + 1));
     }
 
     uint64_t hash = mp-> data-> minfo-> hash (key);
-    _yrt_map_insert_no_resize (mp, hash, key, value);
+    _map_insert_no_resize (mp, hash, key, value);
 }
 
-void _yrt_map_insert_no_resize (_yrt_map_t * mp, uint64_t hash, uint8_t * key, uint8_t * value) {
+void _map_insert_no_resize (_yrt_map_t * mp, uint64_t hash, uint8_t * key, uint8_t * value) {
     uint64_t index = hash % mp-> data-> cap;
     if (mp-> data-> entries [index] != NULL) {
         _yrt_map_entry_t * entry = mp-> data-> entries [index];
-        if (_yrt_map_entry_insert (mp-> data, entry, hash, key, value) == 1) {
+        if (_map_entry_insert (mp-> data, entry, hash, key, value) == 1) {
             mp-> data-> len += 1;
         }
 
         return;
     }
 
-    _yrt_map_create_entry (mp-> data, &(mp-> data-> entries [index]), hash, key, value);
+    _map_create_entry (mp-> data, &(mp-> data-> entries [index]), hash, key, value);
     mp-> data-> loaded += 1;
     mp-> data-> len += 1;
 }
 
-uint8_t _yrt_map_entry_insert (_yrt_map_content_t * data, _yrt_map_entry_t * mp, uint64_t hash, uint8_t * key, uint8_t * value) {
+uint8_t _map_entry_insert (_yrt_map_content_t * data, _yrt_map_entry_t * mp, uint64_t hash, uint8_t * key, uint8_t * value) {
     _yrt_map_info_t * minfo = data-> minfo;
     uint8_t * keyEntry = ((uint8_t*) mp) + sizeof (_yrt_map_entry_t);
     if (minfo-> cmp (key, keyEntry) == 1) {
@@ -122,17 +122,17 @@ uint8_t _yrt_map_entry_insert (_yrt_map_content_t * data, _yrt_map_entry_t * mp,
     }
 
     if (mp-> next != NULL) {
-        return _yrt_map_entry_insert (data, mp-> next, hash, key, value);
+        return _map_entry_insert (data, mp-> next, hash, key, value);
     }
 
-    _yrt_map_create_entry (data, &(mp-> next), hash, key, value);
+    _map_create_entry (data, &(mp-> next), hash, key, value);
     return 1;
 }
 
-void _yrt_map_create_entry (_yrt_map_content_t * data, _yrt_map_entry_t ** entry, uint64_t hash, uint8_t * key, uint8_t * value) {
+void _map_create_entry (_yrt_map_content_t * data, _yrt_map_entry_t ** entry, uint64_t hash, uint8_t * key, uint8_t * value) {
     _yrt_map_info_t * minfo = data-> minfo;
     uint64_t nodeSize = sizeof (_yrt_map_entry_t) + (minfo-> keySize + minfo-> valueSize);
-    uint8_t * newEntry = _yrt_map_entry_alloc (data, nodeSize);
+    uint8_t * newEntry = _map_entry_alloc (data, nodeSize);
     uint8_t * keyEntry = newEntry + sizeof (_yrt_map_entry_t);
     uint8_t * valueEntry = keyEntry + minfo-> keySize;
 
@@ -156,7 +156,7 @@ void _yrt_map_erase (_yrt_map_t * mp, uint8_t * key) {
         return;
     }
 
-    if (_yrt_map_erase_entry (&(mp-> data-> entries [index]), key, mp-> data-> minfo) == 1) {
+    if (_map_erase_entry (&(mp-> data-> entries [index]), key, mp-> data-> minfo) == 1) {
         mp-> data-> len -= 1;
     }
 
@@ -165,11 +165,11 @@ void _yrt_map_erase (_yrt_map_t * mp, uint8_t * key) {
     }
 
     if (((mp-> data-> loaded * 100) / mp-> data-> cap) < MAP_MIN_LOADED_FACTOR) {
-        _yrt_map_fit (mp, _yrt_next_pow2 (mp-> data-> loaded + 1));
+        _map_fit (mp, _next_pow2 (mp-> data-> loaded + 1));
     }
 }
 
-uint8_t _yrt_map_erase_entry (_yrt_map_entry_t ** en, uint8_t * key, _yrt_map_info_t * minfo) {
+uint8_t _map_erase_entry (_yrt_map_entry_t ** en, uint8_t * key, _yrt_map_info_t * minfo) {
     uint8_t * keyEntry = ((uint8_t*) (*en)) + sizeof (_yrt_map_entry_t);
     if (minfo-> cmp (key, keyEntry) == 1) {
         *en = (*en)-> next;
@@ -178,7 +178,7 @@ uint8_t _yrt_map_erase_entry (_yrt_map_entry_t ** en, uint8_t * key, _yrt_map_in
     }
 
     if ((*en)-> next != NULL) {
-        return _yrt_map_erase_entry (&(*en)-> next, key, minfo);
+        return _map_erase_entry (&(*en)-> next, key, minfo);
     }
 
     return 0;
@@ -195,10 +195,10 @@ uint8_t * _yrt_map_find (_yrt_map_t * mp, uint8_t * key) {
         return NULL;
     }
 
-    return _yrt_map_find_entry (mp-> data-> entries [index], key, mp-> data-> minfo);
+    return _map_find_entry (mp-> data-> entries [index], key, mp-> data-> minfo);
 }
 
-uint8_t * _yrt_map_find_entry (_yrt_map_entry_t * en, uint8_t * key, _yrt_map_info_t * minfo) {
+uint8_t * _map_find_entry (_yrt_map_entry_t * en, uint8_t * key, _yrt_map_info_t * minfo) {
     uint8_t * keyEntry = ((uint8_t*) en) + sizeof (_yrt_map_entry_t);
     if (minfo-> cmp (key, keyEntry) == 1) {
         uint8_t * valueEntry = keyEntry + minfo-> keySize;
@@ -209,10 +209,10 @@ uint8_t * _yrt_map_find_entry (_yrt_map_entry_t * en, uint8_t * key, _yrt_map_in
         return NULL;
     }
 
-    return _yrt_map_find_entry (en-> next, key, minfo);
+    return _map_find_entry (en-> next, key, minfo);
 }
 
-void _yrt_map_fit (_yrt_map_t * mp, uint64_t newSize) {
+void _map_fit (_yrt_map_t * mp, uint64_t newSize) {
     if (newSize == 0) {
         _yrt_map_empty (mp, mp-> data-> minfo);
         return;
@@ -230,14 +230,14 @@ void _yrt_map_fit (_yrt_map_t * mp, uint64_t newSize) {
     result.data-> loaded = 0;
     result.data-> len = 0;
 
-    _yrt_map_relink_entries (&result, mp);
+    _map_relink_entries (&result, mp);
     mp-> data-> loaded = data.loaded;
     mp-> data-> len = data.len;
     mp-> data-> cap = data.cap;
     mp-> data-> entries = data.entries;
 }
 
-void _yrt_map_copy_entries (_yrt_map_t * result, _yrt_map_t * old) {
+void _map_copy_entries (_yrt_map_t * result, _yrt_map_t * old) {
     for (uint64_t i = 0 ; i < old-> data-> cap ; i++) {
         if (old-> data-> entries [i] != NULL) {
             _yrt_map_entry_t * head = old-> data-> entries [i];
@@ -246,14 +246,14 @@ void _yrt_map_copy_entries (_yrt_map_t * result, _yrt_map_t * old) {
                 uint8_t * key = ((uint8_t*) head) + sizeof (_yrt_map_entry_t);
                 uint8_t * value = ((uint8_t*) head) + sizeof (_yrt_map_entry_t) + old-> data-> minfo-> keySize;
 
-                _yrt_map_insert_no_resize (result, hash, key, value);
+                _map_insert_no_resize (result, hash, key, value);
                 head = head-> next;
             }
         }
     }
 }
 
-void _yrt_map_relink_entries (_yrt_map_t * result, _yrt_map_t * old) {
+void _map_relink_entries (_yrt_map_t * result, _yrt_map_t * old) {
     for (uint64_t i = 0 ; i < old-> data-> cap ; i++) {
         _yrt_map_entry_t * head = old-> data-> entries [i];
         while (head != NULL) {

--- a/rt/memory/map.c
+++ b/rt/memory/map.c
@@ -21,6 +21,10 @@
 // fields keep the same alignment they would get from a standalone GC_malloc
 #define MAP_ENTRY_ALIGN (sizeof (void*))
 
+// cap is always 0 or a power of two (see _yrt_map_fit/_next_pow2), so bucket index
+// computation can use a mask instead of a division
+#define MAP_BUCKET_INDEX(hash, cap) ((hash) & ((cap) - 1))
+
 /*!
  * ====================================================================================================
  * ====================================================================================================
@@ -88,7 +92,7 @@ void _yrt_dup_map (_yrt_map_t * result, _yrt_map_info_t * info, _yrt_map_t * old
 void _yrt_map_insert (_yrt_map_t * mp, uint8_t * key, uint8_t * value) {
     if (mp-> data-> cap == 0) {
         _map_fit (mp, 1);
-    } else if ((mp-> data-> loaded * 100 / mp-> data-> cap) > MAP_MAX_LOADED_FACTOR) {
+    } else if ((mp-> data-> loaded * 100) > (MAP_MAX_LOADED_FACTOR * mp-> data-> cap)) {
         _map_fit (mp, _next_pow2 (mp-> data-> cap + 1));
     }
 
@@ -97,7 +101,7 @@ void _yrt_map_insert (_yrt_map_t * mp, uint8_t * key, uint8_t * value) {
 }
 
 void _map_insert_no_resize (_yrt_map_t * mp, uint64_t hash, uint8_t * key, uint8_t * value) {
-    uint64_t index = hash % mp-> data-> cap;
+    uint64_t index = MAP_BUCKET_INDEX (hash, mp-> data-> cap);
     if (mp-> data-> entries [index] != NULL) {
         _yrt_map_entry_t * entry = mp-> data-> entries [index];
         if (_map_entry_insert (mp-> data, entry, hash, key, value) == 1) {
@@ -151,7 +155,7 @@ void _yrt_map_erase (_yrt_map_t * mp, uint8_t * key) {
     }
 
     uint64_t hash = mp-> data-> minfo-> hash (key);
-    uint64_t index = hash % mp-> data-> cap;
+    uint64_t index = MAP_BUCKET_INDEX (hash, mp-> data-> cap);
     if (mp-> data-> entries [index] == NULL) {
         return;
     }
@@ -164,7 +168,7 @@ void _yrt_map_erase (_yrt_map_t * mp, uint8_t * key) {
         mp-> data-> loaded -= 1;
     }
 
-    if (((mp-> data-> loaded * 100) / mp-> data-> cap) < MAP_MIN_LOADED_FACTOR) {
+    if ((mp-> data-> loaded * 100) < (MAP_MIN_LOADED_FACTOR * mp-> data-> cap)) {
         _map_fit (mp, _next_pow2 (mp-> data-> loaded + 1));
     }
 }
@@ -190,7 +194,7 @@ uint8_t * _yrt_map_find (_yrt_map_t * mp, uint8_t * key) {
     }
 
     uint64_t hash = mp-> data-> minfo-> hash (key);
-    uint64_t index = hash % mp-> data-> cap;
+    uint64_t index = MAP_BUCKET_INDEX (hash, mp-> data-> cap);
     if (mp-> data-> entries [index] == NULL) {
         return NULL;
     }
@@ -258,7 +262,7 @@ void _map_relink_entries (_yrt_map_t * result, _yrt_map_t * old) {
         _yrt_map_entry_t * head = old-> data-> entries [i];
         while (head != NULL) {
             _yrt_map_entry_t * next = head-> next;
-            uint64_t index = head-> hash % result-> data-> cap;
+            uint64_t index = MAP_BUCKET_INDEX (head-> hash, result-> data-> cap);
 
             if (result-> data-> entries [index] == NULL) {
                 result-> data-> loaded += 1;

--- a/rt/memory/map.c
+++ b/rt/memory/map.c
@@ -10,6 +10,17 @@
 #define MAP_MAX_LOADED_FACTOR 75
 #define MAP_MIN_LOADED_FACTOR 40
 
+// Entry count of the first slab allocated for a map (see _yrt_map_entry_alloc). Each
+// subsequent slab for the same map doubles in size, up to MAP_SLAB_MAX_BYTES, so a map
+// that only ever holds a handful of entries (e.g. one JSON object) does not pay for a
+// slab sized for a map that ends up holding millions.
+#define MAP_SLAB_INITIAL_ENTRIES 1
+#define MAP_SLAB_MAX_BYTES 4096
+
+// All entry nodes are aligned on this boundary within a slab, so hash/next/key/value
+// fields keep the same alignment they would get from a standalone GC_malloc
+#define MAP_ENTRY_ALIGN (sizeof (void*))
+
 /*!
  * ====================================================================================================
  * ====================================================================================================
@@ -25,6 +36,40 @@ void _yrt_map_empty (_yrt_map_t * mp, _yrt_map_info_t * info) {
     mp-> data-> loaded = 0;
     mp-> data-> cap = 0;
     mp-> data-> entries = NULL;
+    mp-> data-> slabCur = NULL;
+    mp-> data-> slabEnd = NULL;
+    mp-> data-> slabSize = 0;
+}
+
+/**
+ * Carve `nodeSize` bytes for a new entry out of `data`'s bump-allocated slab,
+ * allocating a fresh slab first if the current one does not have enough room left.
+ * This turns what used to be one GC_malloc per entry into one GC_malloc per slab,
+ * with slabs growing geometrically (like a vector) instead of a single fixed size,
+ * so a map with few entries does not over-allocate.
+ */
+static uint8_t * _yrt_map_entry_alloc (_yrt_map_content_t * data, uint64_t nodeSize) {
+    uint64_t stride = (nodeSize + MAP_ENTRY_ALIGN - 1) & ~(MAP_ENTRY_ALIGN - 1);
+
+    if (data-> slabCur == NULL || (uint64_t) (data-> slabEnd - data-> slabCur) < stride) {
+        uint64_t slabSize = data-> slabSize == 0 ? stride * MAP_SLAB_INITIAL_ENTRIES : data-> slabSize * 2;
+        if (slabSize > MAP_SLAB_MAX_BYTES && stride <= MAP_SLAB_MAX_BYTES) {
+            slabSize = MAP_SLAB_MAX_BYTES;
+        }
+        if (slabSize < stride) {
+            slabSize = stride;
+        }
+        slabSize = ((slabSize + stride - 1) / stride) * stride;
+
+        data-> slabCur = (uint8_t *) GC_malloc (slabSize);
+        data-> slabEnd = data-> slabCur + slabSize;
+        data-> slabSize = slabSize;
+    }
+
+    uint8_t * result = data-> slabCur;
+    data-> slabCur += stride;
+
+    return result;
 }
 
 void _yrt_dup_map (_yrt_map_t * result, _yrt_map_info_t * info, _yrt_map_t * old) {
@@ -55,19 +100,20 @@ void _yrt_map_insert_no_resize (_yrt_map_t * mp, uint64_t hash, uint8_t * key, u
     uint64_t index = hash % mp-> data-> cap;
     if (mp-> data-> entries [index] != NULL) {
         _yrt_map_entry_t * entry = mp-> data-> entries [index];
-        if (_yrt_map_entry_insert (entry, hash, key, value, mp-> data-> minfo) == 1) {
+        if (_yrt_map_entry_insert (mp-> data, entry, hash, key, value) == 1) {
             mp-> data-> len += 1;
         }
 
         return;
     }
 
-    _yrt_map_create_entry (&(mp-> data-> entries [index]), hash, key, value, mp-> data-> minfo);
+    _yrt_map_create_entry (mp-> data, &(mp-> data-> entries [index]), hash, key, value);
     mp-> data-> loaded += 1;
     mp-> data-> len += 1;
 }
 
-uint8_t _yrt_map_entry_insert (_yrt_map_entry_t * mp, uint64_t hash, uint8_t * key, uint8_t * value, _yrt_map_info_t * minfo) {
+uint8_t _yrt_map_entry_insert (_yrt_map_content_t * data, _yrt_map_entry_t * mp, uint64_t hash, uint8_t * key, uint8_t * value) {
+    _yrt_map_info_t * minfo = data-> minfo;
     uint8_t * keyEntry = ((uint8_t*) mp) + sizeof (_yrt_map_entry_t);
     if (minfo-> cmp (key, keyEntry) == 1) {
         uint8_t * valEntry = keyEntry + minfo-> keySize;
@@ -76,16 +122,17 @@ uint8_t _yrt_map_entry_insert (_yrt_map_entry_t * mp, uint64_t hash, uint8_t * k
     }
 
     if (mp-> next != NULL) {
-        return _yrt_map_entry_insert (mp-> next, hash, key, value, minfo);
+        return _yrt_map_entry_insert (data, mp-> next, hash, key, value);
     }
 
-    _yrt_map_create_entry (&(mp-> next), hash, key, value, minfo);
+    _yrt_map_create_entry (data, &(mp-> next), hash, key, value);
     return 1;
 }
 
-void _yrt_map_create_entry (_yrt_map_entry_t ** entry, uint64_t hash, uint8_t * key, uint8_t * value, _yrt_map_info_t * minfo) {
+void _yrt_map_create_entry (_yrt_map_content_t * data, _yrt_map_entry_t ** entry, uint64_t hash, uint8_t * key, uint8_t * value) {
+    _yrt_map_info_t * minfo = data-> minfo;
     uint64_t nodeSize = sizeof (_yrt_map_entry_t) + (minfo-> keySize + minfo-> valueSize);
-    uint8_t * newEntry = (uint8_t *) GC_malloc (nodeSize);
+    uint8_t * newEntry = _yrt_map_entry_alloc (data, nodeSize);
     uint8_t * keyEntry = newEntry + sizeof (_yrt_map_entry_t);
     uint8_t * valueEntry = keyEntry + minfo-> keySize;
 

--- a/rt/memory/map.h
+++ b/rt/memory/map.h
@@ -45,7 +45,7 @@ void _yrt_map_insert (_yrt_map_t * mp, uint8_t * key, uint8_t * value);
  *    - key: the data of the key
  *    - value: the data of the value
  */
-void _yrt_map_insert_no_resize (_yrt_map_t * mp, uint64_t hash, uint8_t * key, uint8_t * value);
+void _map_insert_no_resize (_yrt_map_t * mp, uint64_t hash, uint8_t * key, uint8_t * value);
 /**
  * Insert an element in the map entry linked list
  * @params:
@@ -55,12 +55,12 @@ void _yrt_map_insert_no_resize (_yrt_map_t * mp, uint64_t hash, uint8_t * key, u
  *    - value: the data of the value
  * @returns: true if new entry, false if replaced
  */
-uint8_t _yrt_map_entry_insert (_yrt_map_content_t * data, _yrt_map_entry_t * en, uint64_t hash, uint8_t * key, uint8_t * value);
+uint8_t _map_entry_insert (_yrt_map_content_t * data, _yrt_map_entry_t * en, uint64_t hash, uint8_t * key, uint8_t * value);
 
 /**
- * Allocate a map entry, bump-allocated out of data's entry slab (see _yrt_map_entry_alloc in map.c)
+ * Allocate a map entry, bump-allocated out of data's entry slab (see _map_entry_alloc in map.c)
  */
-void _yrt_map_create_entry (_yrt_map_content_t * data, _yrt_map_entry_t ** en, uint64_t hash, uint8_t * key, uint8_t * value);
+void _map_create_entry (_yrt_map_content_t * data, _yrt_map_entry_t ** en, uint64_t hash, uint8_t * key, uint8_t * value);
 
 /**
  * Erase data from the map
@@ -70,7 +70,7 @@ void _yrt_map_erase (_yrt_map_t * mp, uint8_t * key);
 /**
  * Erase a key from the linked list
  */
-uint8_t _yrt_map_erase_entry (_yrt_map_entry_t ** en, uint8_t * key, _yrt_map_info_t * minfo);
+uint8_t _map_erase_entry (_yrt_map_entry_t ** en, uint8_t * key, _yrt_map_info_t * minfo);
 
 /**
  * Lookup wheter the key exists in the map
@@ -93,30 +93,30 @@ uint8_t * _yrt_map_find (_yrt_map_t * mp, uint8_t * key);
  *    - 0 if not found, 1 otherwise
  *    - value: the value
  */
-uint8_t * _yrt_map_find_entry (_yrt_map_entry_t * en, uint8_t * key, _yrt_map_info_t * minfo);
+uint8_t * _map_find_entry (_yrt_map_entry_t * en, uint8_t * key, _yrt_map_info_t * minfo);
 
 /**
  * Change the size of the map to decrease the complexity of access/insert or to decrease the amount of unused indexes
  */
-void _yrt_map_fit (_yrt_map_t * mp, uint64_t newSize);
+void _map_fit (_yrt_map_t * mp, uint64_t newSize);
 
 /**
  * Insert all the key-> values from old into result
  * @assume: result has allocated data array
  * @warning: result is not be resized
  */
-void _yrt_map_copy_entries (_yrt_map_t * result, _yrt_map_t * old);
+void _map_copy_entries (_yrt_map_t * result, _yrt_map_t * old);
 
 /**
  * Move all the entries of old into result, rebucketing them for result's capacity
- * @info: unlike _yrt_map_copy_entries, this does not allocate new entry nodes - the
+ * @info: unlike _map_copy_entries, this does not allocate new entry nodes - the
  *   existing nodes are relinked into result's bucket array. Only valid when old and
- *   result are the same logical map being resized in place (e.g. from _yrt_map_fit),
+ *   result are the same logical map being resized in place (e.g. from _map_fit),
  *   since old's nodes are consumed rather than duplicated - never use this to produce
  *   an independent copy of a map still in use.
  * @assume: result has allocated data array
  */
-void _yrt_map_relink_entries (_yrt_map_t * result, _yrt_map_t * old);
+void _map_relink_entries (_yrt_map_t * result, _yrt_map_t * old);
 
 
 

--- a/rt/memory/map.h
+++ b/rt/memory/map.h
@@ -55,12 +55,12 @@ void _yrt_map_insert_no_resize (_yrt_map_t * mp, uint64_t hash, uint8_t * key, u
  *    - value: the data of the value
  * @returns: true if new entry, false if replaced
  */
-uint8_t _yrt_map_entry_insert (_yrt_map_entry_t * en, uint64_t hash, uint8_t * key, uint8_t * value, _yrt_map_info_t * minfo);
+uint8_t _yrt_map_entry_insert (_yrt_map_content_t * data, _yrt_map_entry_t * en, uint64_t hash, uint8_t * key, uint8_t * value);
 
 /**
- * Allocate a map entry
+ * Allocate a map entry, bump-allocated out of data's entry slab (see _yrt_map_entry_alloc in map.c)
  */
-void _yrt_map_create_entry (_yrt_map_entry_t ** en, uint64_t hash, uint8_t * key, uint8_t * value, _yrt_map_info_t * minfo);
+void _yrt_map_create_entry (_yrt_map_content_t * data, _yrt_map_entry_t ** en, uint64_t hash, uint8_t * key, uint8_t * value);
 
 /**
  * Erase data from the map

--- a/rt/memory/map.h
+++ b/rt/memory/map.h
@@ -70,7 +70,7 @@ void _yrt_map_erase (_yrt_map_t * mp, uint8_t * key);
 /**
  * Erase a key from the linked list
  */
-uint8_t _map_erase_entry (_yrt_map_entry_t ** en, uint8_t * key, _yrt_map_info_t * minfo);
+uint8_t _map_erase_entry (_yrt_map_entry_t ** en, uint64_t hash, uint8_t * key, _yrt_map_info_t * minfo);
 
 /**
  * Lookup wheter the key exists in the map
@@ -93,7 +93,7 @@ uint8_t * _yrt_map_find (_yrt_map_t * mp, uint8_t * key);
  *    - 0 if not found, 1 otherwise
  *    - value: the value
  */
-uint8_t * _map_find_entry (_yrt_map_entry_t * en, uint8_t * key, _yrt_map_info_t * minfo);
+uint8_t * _map_find_entry (_yrt_map_entry_t * en, uint64_t hash, uint8_t * key, _yrt_map_info_t * minfo);
 
 /**
  * Change the size of the map to decrease the complexity of access/insert or to decrease the amount of unused indexes

--- a/rt/memory/map.h
+++ b/rt/memory/map.h
@@ -107,6 +107,17 @@ void _yrt_map_fit (_yrt_map_t * mp, uint64_t newSize);
  */
 void _yrt_map_copy_entries (_yrt_map_t * result, _yrt_map_t * old);
 
+/**
+ * Move all the entries of old into result, rebucketing them for result's capacity
+ * @info: unlike _yrt_map_copy_entries, this does not allocate new entry nodes - the
+ *   existing nodes are relinked into result's bucket array. Only valid when old and
+ *   result are the same logical map being resized in place (e.g. from _yrt_map_fit),
+ *   since old's nodes are consumed rather than duplicated - never use this to produce
+ *   an independent copy of a map still in use.
+ * @assume: result has allocated data array
+ */
+void _yrt_map_relink_entries (_yrt_map_t * result, _yrt_map_t * old);
+
 
 
 /*!

--- a/rt/memory/print.c
+++ b/rt/memory/print.c
@@ -9,13 +9,13 @@
 void _yrt_putwchar (uint32_t code) {
     char c[5];
     int nb = 0;
-    printf ("%s", _yrt_to_utf8 (code, c, &nb));
+    printf ("%s", _to_utf8 (code, c, &nb));
 }
 
 void _yrt_eputwchar (uint32_t code) {
     char c[5];
     int nb = 0;
-    fprintf (stderr, "%s", _yrt_to_utf8 (code, c, &nb));
+    fprintf (stderr, "%s", _to_utf8 (code, c, &nb));
 }
 
 void _yrt_printf32 (float x) {
@@ -96,7 +96,7 @@ void _yrt_eprintfsize (long double x) {
     }
 }
 
-void _yrt_print_error (char * format) {
+void _print_error (char * format) {
     fprintf (stderr, "%s", format);
 }
 

--- a/rt/memory/print.h
+++ b/rt/memory/print.h
@@ -16,7 +16,7 @@ void _yrt_eprintf32 (float x);
 void _yrt_eprintf64 (double x);
 void _yrt_eprintf80 (long double x);
 void _yrt_eprintfsize (long double x);
-void _yrt_print_error (char * format);
+void _print_error (char * format);
 
 void _yrt_fflush_stdout ();
 

--- a/rt/memory/tinfo.c
+++ b/rt/memory/tinfo.c
@@ -36,7 +36,7 @@ void* _yrt_unsafe_cast (void* x) {
     return x;
 }
 
-_yrt_slice_t _yrt_type_typeinfo_name (_yrt_slice_t mangled) {
+_yrt_slice_t _type_typeinfo_name (_yrt_slice_t mangled) {
     _yrt_slice_t name = str_copy_len ("_Y", 2);
 
 	_yrt_slice_t tmp = str_create_len (mangled.data, mangled.len);
@@ -49,7 +49,7 @@ _yrt_slice_t _yrt_type_typeinfo_name (_yrt_slice_t mangled) {
 }
 
 
-_yrt_slice_t _yrt_type_vtable_name (_yrt_slice_t mangled) {
+_yrt_slice_t _type_vtable_name (_yrt_slice_t mangled) {
     _yrt_slice_t name = str_copy_len ("_Y", 2);
 	_yrt_slice_t tmp = str_create_len (mangled.data, mangled.len);
 
@@ -62,7 +62,7 @@ _yrt_slice_t _yrt_type_vtable_name (_yrt_slice_t mangled) {
 }
 
 
-_yrt_slice_t _yrt_type_constructor_no_param_name (_yrt_slice_t mangled) {
+_yrt_slice_t _type_constructor_no_param_name (_yrt_slice_t mangled) {
     _yrt_slice_t name = str_copy_len ("_Y", 2);
 
 	_yrt_slice_t tmp = str_create_len (mangled.data, mangled.len);

--- a/rt/memory/tinfo.h
+++ b/rt/memory/tinfo.h
@@ -20,18 +20,18 @@ char _yrt_type_equals (_yrt_type_info a, _yrt_type_info b);
 /**
  * \return the name of the typeinfo symbol of a class from the class name (mangled)
  */
-_yrt_slice_t _yrt_type_typeinfo_name (_yrt_slice_t className);
+_yrt_slice_t _type_typeinfo_name (_yrt_slice_t className);
 
 /**
  * \return the name of the vtable symbol of a class from the class name
  */
-_yrt_slice_t _yrt_type_vtable_name (_yrt_slice_t className);
+_yrt_slice_t _type_vtable_name (_yrt_slice_t className);
 
 /**
  * \return the name of the constructor with no parameters of the class (mangled)
  * \info, its just the name, there is no check wether there is really such a constructor
  */
-_yrt_slice_t _yrt_type_constructor_no_param_name (_yrt_slice_t className);
+_yrt_slice_t _type_constructor_no_param_name (_yrt_slice_t className);
 
 /**
  * Unsafe cast that does nothing

--- a/rt/memory/types.h
+++ b/rt/memory/types.h
@@ -59,7 +59,7 @@ typedef struct _yrt_map_content_t {
     uint64_t loaded;
 
     // Bump allocator used to carve entry nodes out of a shared block, instead of
-    // one GC_malloc per entry - see _yrt_map_entry_alloc in map.c
+    // one GC_malloc per entry - see _map_entry_alloc in map.c
     uint8_t * slabCur;
     uint8_t * slabEnd;
     uint64_t slabSize; // size in bytes of the slab slabCur/slabEnd currently point into

--- a/rt/memory/types.h
+++ b/rt/memory/types.h
@@ -57,6 +57,12 @@ typedef struct _yrt_map_content_t {
     uint64_t len;
     uint64_t cap;
     uint64_t loaded;
+
+    // Bump allocator used to carve entry nodes out of a shared block, instead of
+    // one GC_malloc per entry - see _yrt_map_entry_alloc in map.c
+    uint8_t * slabCur;
+    uint8_t * slabEnd;
+    uint64_t slabSize; // size in bytes of the slab slabCur/slabEnd currently point into
 } _yrt_map_content_t;
 
 typedef struct _yrt_map_t {

--- a/rt/run.c
+++ b/rt/run.c
@@ -31,7 +31,7 @@ void bt_sighandler(int sig
     static int first = 0;
     if (first == 0) {
         first = 1;
-        _yrt_exc_panic_seg_fault ();
+        _exc_panic_seg_fault ();
     } else {
         _yrt_exc_panic_no_trace ();
     }
@@ -60,11 +60,11 @@ void _yrt_init_runtime (int isDebug) {
     __YRT_DEBUG__ = isDebug;
 
     GC_INIT ();
-    _yrt_gc_add_tls_roots (); // spawned threads get theirs in _yrt_thread_create
+    _gc_add_tls_roots (); // spawned threads get theirs in _thread_create
 
-    _yrt_atomic_init ();
+    _atomic_init ();
     installHandler ();
-    _yrt_exc_init ();
+    _exc_init ();
 }
 
 void _yrt_force_debug (int act) {
@@ -95,11 +95,11 @@ _yrt_slice_t _yrt_get_main_args () {
     return __MAIN_ARGS__;
 }
 
-int _yrt_get_test_code () {
+int _get_test_code () {
     return __YRT_TEST_CODE__;
 }
 
-void _yrt_set_test_code (int i) {
+void _set_test_code (int i) {
     __YRT_TEST_CODE__ = i;
 }
 

--- a/rt/utils/demangle.c
+++ b/rt/utils/demangle.c
@@ -5,7 +5,7 @@
 
 // _Y4core5array10OutOfArray4selfFxP24x4core5array10OutOfArrayZxP24x4core5array10OutOfArray0
 
-int _yrt_demangle_number (char * data, int * current) {
+int _demangle_number (char * data, int * current) {
     int nb = 0;
     while (*data >= '0' && *data <= '9') {
 		*current += 1;
@@ -16,7 +16,7 @@ int _yrt_demangle_number (char * data, int * current) {
     return nb;
 }
 					  
-_yrt_slice_t _yrt_demangle_symbol (char * data, uint64_t len) {
+_yrt_slice_t _demangle_symbol (char * data, uint64_t len) {
 
     if (len <= 2 || data [0] != '_' || data [1] != 'Y') {
 		return str_create_len (data, len);
@@ -27,7 +27,7 @@ _yrt_slice_t _yrt_demangle_symbol (char * data, uint64_t len) {
     int i = 0;
     while (current < len) {
 
-		int nb = _yrt_demangle_number (data + current, &current);
+		int nb = _demangle_number (data + current, &current);
 		if (nb != 0 && nb + current < len) {
 			if (i != 0) {
 				_yrt_slice_t tmp = str_create ("::");
@@ -50,11 +50,11 @@ _yrt_slice_t _yrt_demangle_symbol (char * data, uint64_t len) {
     return ret;    
 }
 
-_yrt_slice_t _yrt_demangle_symbol_to_slice (char * data, uint64_t len) {
-    return _yrt_demangle_symbol (data, len);
+_yrt_slice_t _demangle_symbol_to_slice (char * data, uint64_t len) {
+    return _demangle_symbol (data, len);
 }
 
-_yrt_slice_t _yrt_mangle_path (_yrt_slice_t data) {
+_yrt_slice_t _mangle_path (_yrt_slice_t data) {
     _yrt_slice_t str = str_empty ();
     int current = 0;
     int start = 0;

--- a/rt/utils/demangle.h
+++ b/rt/utils/demangle.h
@@ -8,17 +8,17 @@
 /**
  * Retreive the next number
  */
-int _yrt_demangle_number (char * data, int * current);
+int _demangle_number (char * data, int * current);
 
 /**
  * Demangle the name of a symbol
  */
-_yrt_slice_t _yrt_demangle_symbol (char * data, uint64_t len);
+_yrt_slice_t _demangle_symbol (char * data, uint64_t len);
 
 /**
  * Demangle the name of a symbol
  */
-_yrt_slice_t _yrt_demangle_symbol_to_slice (char * data, uint64_t len);
+_yrt_slice_t _demangle_symbol_to_slice (char * data, uint64_t len);
 
 /**
  * Demangle the parameters of a function
@@ -28,6 +28,6 @@ _yrt_slice_t _yrt_demangle_function_parameters (char * data, uint64_t len);
 /**
  * Mangle the name of a class 
  */
-_yrt_slice_t _yrt_mangle_path (_yrt_slice_t name);
+_yrt_slice_t _mangle_path (_yrt_slice_t name);
 
 #endif

--- a/rt/utils/gc.c
+++ b/rt/utils/gc.c
@@ -32,7 +32,7 @@ uint8_t _yrt_is_GC_enabled () {
 static size_t __TLS_BLOCK_SIZE__ = 0;
 static int __TLS_BLOCK_SIZE_READ__ = 0;
 
-static int _yrt_read_tls_phdr (struct dl_phdr_info * info, size_t size, void * data) {
+static int _read_tls_phdr (struct dl_phdr_info * info, size_t size, void * data) {
     (void) size;
 
     // The main executable is the only object with an empty name. Shared objects are skipped on
@@ -52,11 +52,11 @@ static int _yrt_read_tls_phdr (struct dl_phdr_info * info, size_t size, void * d
 
 /**
  * Compute the bounds of the calling thread's static TLS block
- * @info: primed by _yrt_gc_add_tls_roots from _yrt_init_runtime, while still single threaded
+ * @info: primed by _gc_add_tls_roots from _yrt_init_runtime, while still single threaded
  * */
-static void _yrt_tls_bounds (char ** lo, char ** hi) {
+static void _tls_bounds (char ** lo, char ** hi) {
     if (!__TLS_BLOCK_SIZE_READ__) {
-        dl_iterate_phdr (&_yrt_read_tls_phdr, &__TLS_BLOCK_SIZE__);
+        dl_iterate_phdr (&_read_tls_phdr, &__TLS_BLOCK_SIZE__);
         __TLS_BLOCK_SIZE_READ__ = 1;
     }
 
@@ -65,23 +65,23 @@ static void _yrt_tls_bounds (char ** lo, char ** hi) {
     *lo = tp - __TLS_BLOCK_SIZE__;
 }
 
-void _yrt_gc_add_tls_roots () {
+void _gc_add_tls_roots () {
     char * lo, * hi;
-    _yrt_tls_bounds (&lo, &hi);
+    _tls_bounds (&lo, &hi);
 
     if (lo != hi) GC_add_roots (lo, hi);
 }
 
-void _yrt_gc_remove_tls_roots () {
+void _gc_remove_tls_roots () {
     char * lo, * hi;
-    _yrt_tls_bounds (&lo, &hi);
+    _tls_bounds (&lo, &hi);
 
     if (lo != hi) GC_remove_roots (lo, hi);
 }
 
 #else
 
-void _yrt_gc_add_tls_roots () {}
-void _yrt_gc_remove_tls_roots () {}
+void _gc_add_tls_roots () {}
+void _gc_remove_tls_roots () {}
 
 #endif

--- a/rt/utils/gc.h
+++ b/rt/utils/gc.h
@@ -24,16 +24,16 @@ uint8_t _yrt_is_GC_enabled ();
  * is therefore invisible to the collector, and gets freed while the thread is still using it.
  * Registering the block makes '@thread' globals ordinary roots.
  *
- * Called by _yrt_init_runtime for the main thread, and by _yrt_thread_create for every thread
+ * Called by _yrt_init_runtime for the main thread, and by _thread_create for every thread
  * it spawns. A caller that registers a thread must unregister it before the thread dies: glibc
  * recycles a dead thread's TLS block for the next one, so a root left behind would both retain
  * garbage and be scanned after the block has been reused.
  * */
-void _yrt_gc_add_tls_roots ();
+void _gc_add_tls_roots ();
 
 /**
- * Unregister the calling thread's static TLS block, undoing _yrt_gc_add_tls_roots
+ * Unregister the calling thread's static TLS block, undoing _gc_add_tls_roots
  * */
-void _yrt_gc_remove_tls_roots ();
+void _gc_remove_tls_roots ();
 
 #endif // GC_H_

--- a/rt/utils/math.c
+++ b/rt/utils/math.c
@@ -4,6 +4,6 @@
 #include <stdlib.h>
 #include <time.h>
 
-float _yrt_sqrt (float x) {
+float _sqrt (float x) {
     return sqrt (x);
 }

--- a/rt/utils/math.h
+++ b/rt/utils/math.h
@@ -1,6 +1,6 @@
 #ifndef MATH_H_
 #define MATH_H_
 
-float _yrt_sqrt (float x);
+float _sqrt (float x);
 
 #endif // MATH_H_


### PR DESCRIPTION
## Summary
- Fix core::types::map resizing so entries are relinked in place instead of reallocated/reinserted on every grow/shrink (`_yrt_map_fit` -> `_map_relink_entries`)
- Replace the mod-heavy polynomial slice hash (two `%` per byte) with a division-free FNV-1a-style combiner, used by every `[c8]`-keyed map
- Bump-allocate map entries from a per-map growing slab instead of one `GC_malloc` per entry, with slab size starting small and doubling per map so short-lived, few-entry maps (e.g. one JSON object) don't over-allocate
- Rename `_yrt_`-prefixed functions that are purely internal to `rt/` (not called by `gyc` codegen or by any Ymir `extern (C)` binding) to drop the `yrt_` segment, so the runtime's public C ABI surface is visually distinguishable from internal implementation details

## Test plan
- [x] Full `midgard_tests` suite (131 tests) passes after each commit, including concurrency/atomic and config/json/toml tests
- [x] Dedicated insert/erase/resize stress test (200k random ops) verified correct and leak-free under `valgrind --memcheck`
- [x] Benchmarked (`--release`) against a synthetic 2M-entry raw map workload and a 3MB/20,500-object JSON file; confirmed no regression, verified real speedup at each step, and diagnosed/fixed a linker regression caused by the rename (root-caused via `nm` undefined-symbol analysis before reverting the 6 functions that turned out to be part of the ABI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)