### PR TITLE
[YMI-152][fix] Use braces rather than a double semicolon in fromStringZ

### DIFF
--- a/midgard/std/conv.yr
+++ b/midgard/std/conv.yr
@@ -903,7 +903,7 @@ pub fn toStringZ(a: [c8])-> *c8 {
 pub fn fromStringZ {U of [c8]} (a: U)-> [c8] {
     let mut len = 0us;
     for i in a {
-        if (i == '\u{0}') break;;
+        if (i == '\u{0}') { break; }
         else len += 1us;
     }
 


### PR DESCRIPTION
## Summary
- `std/conv.yr:906` wrote `if (i == '\u{0}') break;;`. The second `;` was not a stray character: `break` reads its own `;` in the parser, so a further one is what `readBlockOrSingleExpr` consumes to wrap the branch in a block whose value is void — the job `{ }` normally does. It was the only occurrence in the whole standard library.
- ymirc is being corrected so that an instruction which already read its own `;` no longer requires a second one (`SyntaxVisitor::needClosingExpr`). `break`, `continue`, `panic`, `return`, `throw` and `yield` all read theirs, and the block loop asking again meant any two of them in a row failed to parse: `return 0; return i;` reported *"read return, but expected ;"* instead of letting the validator say *"unreachable statement"*, and `yield 1; yield 2;` — not dead code, a `yield` does not end the scope — could not be written at all.
- That fix drops the `;;` spelling, so this line is rewritten to say what it means: `if (i == '\u{0}') { break; }`.

Linear: [YMI-152](https://linear.app/ymir-bootstrap/issue/YMI-152/stdconvfromstringz-uses-break-to-make-an-if-branch-void)

## Ordering
This must be installed before the matching ymirc commit builds — ymirc compiles against the installed standard library, and after that commit `break;;` no longer parses. `gyc` accepts both spellings, so this change is safe to land on its own first.

## Test plan
- [x] `gyc` compiles and runs `if (test) { break; } else ...` with identical behaviour to the `break;;` form (standalone reproduction of `fromStringZ`'s loop, asserted on a NUL-terminated slice)
- [x] ymirc's full suite (295 tests) green against the patched library, including the `format_string` and `regressions::mut_future_syntax` cases that parse `std::conv`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PMT6kkVL94pQFKDxrw4uUP