### PR TITLE
[YMI-168][fix] DateTime: yearDay returns the weekday, and toStream prints the raw 0-based month

### DIFF
--- a/midgard/std/time/date.yr
+++ b/midgard/std/time/date.yr
@@ -154,11 +154,11 @@ pub record DateTime {
     }
 
     /**
-     * @returns: the month in the year
+     * @returns: the month in the year, 1-based (`1` = January, `12` = December)
      * */
     @field
     pub fn month(self)-> i32 {
-        self._value.tm_mon
+        self._value.tm_mon + 1
     }
 
     /**
@@ -178,11 +178,11 @@ pub record DateTime {
     }
 
     /**
-     * @returns: the day in the year
+     * @returns: the day in the year, 0-based (`0` = January 1st)
      * */
     @field
     pub fn yearDay(self)-> i32 {
-        self._value.tm_wday
+        self._value.tm_yday
     }
 
     /*!
@@ -202,15 +202,15 @@ pub record DateTime {
                 stream:.write(self._value.tm_mday);
             }
 
-            if self._value.tm_mon < 10 {
-                stream:.write("/0", self._value.tm_mon);
-            } else { stream:.write("/", self._value.tm_mon); }
+            if self.month < 10 {
+                stream:.write("/0", self.month);
+            } else { stream:.write("/", self.month); }
 
             if self.year > 2000 {
-                if (self.year % 2000) < 10 {
-                    stream:.write("/0", self.year % 2000);
+                if (self.year % 100) < 10 {
+                    stream:.write("/0", self.year % 100);
                 } else {
-                    stream:.write("/", self.year % 2000);
+                    stream:.write("/", self.year % 100);
                 }
             } else {
                 stream:.write("/", self.year);

--- a/tests/time.yr
+++ b/tests/time.yr
@@ -34,7 +34,8 @@ __test {
     // and the mutex is still usable afterwards
     let d2 = DateTime(sec-> 30, min-> 15, hour-> 12, day-> 24, month-> 11, year-> 121);
     assert(d2.second == 30 && d2.minute == 15 && d2.hour == 12);
-    assert(d2.day == 24 && d2.month == 11 && d2.year == 2021);
+    // the ctor takes a 0-based month (tm_mon), the getter reports it 1-based
+    assert(d2.day == 24 && d2.month == 12 && d2.year == 2021);
 
     assert(DateTime(d2.instant()).instant().sec == d2.instant().sec);
 }
@@ -42,5 +43,15 @@ __test {
 __test {
     // january 33rd is normalized to february 2nd (cf. mktime)
     let d = DateTime(day-> 33, month-> 0, year-> 121);
-    assert(d.month == 1 && d.day == 2);
+    assert(d.month == 2 && d.day == 2);
+}
+
+__test {
+    // YMI-168: yearDay must return tm_yday, not the weekday, and toStream must print
+    // a 1-based month and a two-digit (year % 100) year.
+    let d = DateTime(usec-> 0u64, sec-> 0, min-> 0, hour-> 12, day-> 25, month-> 11, year-> 126);
+    assert(d.month == 12);
+    assert(d.yearDay == 358);
+    assert(d.weekDay != d.yearDay);
+    assert(d.to![c8] () == "25/12/26 12:00:00");
 }


### PR DESCRIPTION
Fixes [YMI-168](https://linear.app/ymir-bootstrap/issue/YMI-168).

Two independent defects in `midgard/std/time/date.yr`:

- **`yearDay` returned `tm_wday`** — now returns `tm_yday`, so it is no longer indistinguishable from `weekDay`.
- **`month` / `toStream` printed the raw 0-based `tm_mon`** (December → `/11`, January → `/00`). Both now use a 1-based month, matching how the `year` getter already corrects `tm_year + 1900`. Doc comments note the convention; the constructor still takes a 0-based `tm_mon`.
- While there: `toStream` two-digit year fixed from `year % 2000` (2100 → `/100`) to `year % 100`.

Tests: added `time::4` covering the ticket repro (`25/12/26 12:00:00`, `yearDay == 358`, `weekDay != yearDay`) and updated the two existing tests that asserted the old 0-based getter. Full suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)